### PR TITLE
Added: mutating `NonLinModel`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4

--- a/docs/src/internals/sim_model.md
+++ b/docs/src/internals/sim_model.md
@@ -7,8 +7,8 @@ Pages = ["sim_model.md"]
 ## State-Space Functions
 
 ```@docs
-ModelPredictiveControl.f
-ModelPredictiveControl.h
+ModelPredictiveControl.f!
+ModelPredictiveControl.h!
 ```
 
 ## Steady-State Calculation

--- a/docs/src/internals/state_estim.md
+++ b/docs/src/internals/state_estim.md
@@ -7,8 +7,8 @@ Pages = ["state_estim.md"]
 ## Augmented Model
 
 ```@docs
-ModelPredictiveControl.f̂
-ModelPredictiveControl.ĥ
+ModelPredictiveControl.f̂!
+ModelPredictiveControl.ĥ!
 ```
 
 ## Constraint Relaxation

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -226,7 +226,9 @@ function predictstoch!(
     isnothing(ym) && error("Predictive controllers with InternalModel need the measured "*
                            "outputs ym in keyword argument to compute control actions u")
     Ŷop, ny, yop = mpc.Ŷop, estim.model.ny, estim.model.yop
-    ŷd = h(estim.model, estim.x̂d, d - estim.model.dop) .+ estim.model.yop 
+    ŷd = similar(estim.model.yop)
+    h!(ŷd, estim.model, estim.x̂d, d - estim.model.dop)
+    ŷd .+= estim.model.yop 
     ŷs = zeros(NT, estim.model.ny)
     ŷs[estim.i_ym] .= @views ym .- ŷd[estim.i_ym]  # ŷs=0 for unmeasured outputs
     Ŷop_LHS = similar(Ŷop)

--- a/src/estimator/internal_model.jl
+++ b/src/estimator/internal_model.jl
@@ -272,7 +272,8 @@ estimate its outputs ``\mathbf{ŷ}(k)``, since the strategy imposes that
 """
 function evalŷ(estim::InternalModel{NT}, ym, d) where NT<:Real
     ŷ = Vector{NT}(undef, estim.model.ny)
-    ŷ = h!(ŷ, estim.model, estim.x̂d, d - estim.model.dop) .+ estim.model.yop
+    h!(ŷ, estim.model, estim.x̂d, d - estim.model.dop) 
+    ŷ .+= estim.model.yop
     ŷ[estim.i_ym] = ym
     return ŷ
 end

--- a/src/estimator/internal_model.jl
+++ b/src/estimator/internal_model.jl
@@ -144,20 +144,20 @@ function matrices_internalmodel(model::SimModel{NT}) where NT<:Real
 end
 
 @doc raw"""
-    f̂(::InternalModel, model::NonLinModel, x̂, u, d)
+    f̂!(x̂next, ::InternalModel, model::NonLinModel, x̂, u, d)
 
 State function ``\mathbf{f̂}`` of [`InternalModel`](@ref) for [`NonLinModel`](@ref).
 
-It calls `model.f(x̂, u ,d)` since this estimator does not augment the states.
+It calls `model.f!(x̂next, x̂, u ,d)` since this estimator does not augment the states.
 """
-f̂(::InternalModel, model::NonLinModel, x̂, u, d) = model.f(x̂, u, d)
+f̂!(x̂next, ::InternalModel, model::NonLinModel, x̂, u, d) = model.f!(x̂next, x̂, u, d)
 
 @doc raw"""
-    ĥ(::InternalModel, model::NonLinModel, x̂, d)
+    ĥ!(ŷ, ::InternalModel, model::NonLinModel, x̂, d)
 
-Output function ``\mathbf{ĥ}`` of [`InternalModel`](@ref), it calls `model.h`.
+Output function ``\mathbf{ĥ}`` of [`InternalModel`](@ref), it calls `model.h!`.
 """
-ĥ(::InternalModel, model::NonLinModel, x̂, d) = model.h(x̂, d)
+ĥ!(x̂next, ::InternalModel, model::NonLinModel, x̂, d) = model.h!(x̂next, x̂, d)
 
 
 @doc raw"""
@@ -218,12 +218,17 @@ function update_estimate!(
     model = estim.model
     x̂d, x̂s = estim.x̂d, estim.x̂s
     # -------------- deterministic model ---------------------
-    ŷd = h(model, x̂d, d)
-    x̂d[:] = f(model, x̂d, u, d) # this also updates estim.x̂ (they are the same object)
+    ŷd, x̂dnext = Vector{NT}(undef, model.ny), Vector{NT}(undef, model.nx)
+    h!(ŷd, model, x̂d, d)
+    f!(x̂dnext, model, x̂d, u, d) 
+    x̂d .= x̂dnext # this also updates estim.x̂ (they are the same object)
     # --------------- stochastic model -----------------------
+    x̂snext = Vector{NT}(undef, estim.nxs)
     ŷs = zeros(NT, model.ny)
     ŷs[estim.i_ym] = ym - ŷd[estim.i_ym]   # ŷs=0 for unmeasured outputs
-    x̂s[:] = estim.Âs*x̂s + estim.B̂s*ŷs
+    mul!(x̂snext, estim.Âs, x̂s)
+    mul!(x̂snext, estim.B̂s, ŷs, 1, 1)
+    x̂s .= x̂snext
     return nothing
 end
 
@@ -247,11 +252,12 @@ This estimator does not augment the state vector, thus ``\mathbf{x̂ = x̂_d}``.
 """
 function init_estimate!(estim::InternalModel, model::LinModel{NT}, u, ym, d) where NT<:Real
     x̂d, x̂s = estim.x̂d, estim.x̂s
-    x̂d[:] = (I - model.A)\(model.Bu*u + model.Bd*d)
-    ŷd = h(model, x̂d, d)
+    x̂d .= (I - model.A)\(model.Bu*u + model.Bd*d)
+    ŷd = Vector{NT}(undef, model.ny)
+    h!(ŷd, model, x̂d, d)
     ŷs = zeros(NT, model.ny)
     ŷs[estim.i_ym] = ym - ŷd[estim.i_ym]  # ŷs=0 for unmeasured outputs
-    x̂s[:] = (I-estim.Âs)\estim.B̂s*ŷs
+    x̂s .= (I-estim.Âs)\estim.B̂s*ŷs
     return nothing
 end
 

--- a/src/estimator/internal_model.jl
+++ b/src/estimator/internal_model.jl
@@ -261,6 +261,22 @@ function init_estimate!(estim::InternalModel, model::LinModel{NT}, u, ym, d) whe
     return nothing
 end
 
+@doc raw"""
+    evalŷ(estim::InternalModel, ym, d) -> ŷ
+
+Get [`InternalModel`](@ref) output `ŷ` from current measured outputs `ym` and dist. `d`.
+
+[`InternalModel`](@ref) estimator needs current measured outputs ``\mathbf{y^m}(k)`` to 
+estimate its outputs ``\mathbf{ŷ}(k)``, since the strategy imposes that 
+``\mathbf{ŷ^m}(k) = \mathbf{y^m}(k)`` is always true.
+"""
+function evalŷ(estim::InternalModel{NT}, ym, d) where NT<:Real
+    ŷ = Vector{NT}(undef, estim.model.ny)
+    ŷ = h!(ŷ, estim.model, estim.x̂d, d - estim.model.dop) .+ estim.model.yop
+    ŷ[estim.i_ym] = ym
+    return ŷ
+end
+
 "Print InternalModel information without i/o integrators."
 function print_estim_dim(io::IO, estim::InternalModel, n)
     nu, nd = estim.model.nu, estim.model.nd

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -569,6 +569,7 @@ function update_estimate!(estim::UnscentedKalmanFilter{NT}, u, ym, d) where NT<:
     # --- initialize matrices ---
     X̂  = Matrix{NT}(undef, nx̂, nσ)
     ŷm = Vector{NT}(undef, nym)
+    ŷ  = Vector{NT}(undef, estim.model.ny)
     Ŷm = Matrix{NT}(undef, nym, nσ)
     sqrt_P̂ = LowerTriangular{NT, Matrix{NT}}(Matrix{NT}(undef, nx̂, nx̂))
     # --- correction step ---
@@ -578,7 +579,8 @@ function update_estimate!(estim::UnscentedKalmanFilter{NT}, u, ym, d) where NT<:
     X̂[:, 2:nx̂+1]   .+= γ_sqrt_P̂
     X̂[:, nx̂+2:end] .-= γ_sqrt_P̂
     for j in axes(Ŷm, 2)
-        Ŷm[:, j] = @views ĥ(estim, estim.model, X̂[:, j], d)[estim.i_ym]
+        @views ĥ!(ŷ, estim, estim.model, X̂[:, j], d)
+        @views Ŷm[:, j] .= ŷ[estim.i_ym]
     end
     mul!(ŷm, Ŷm, m̂)
     X̄, Ȳm = X̂, Ŷm
@@ -600,7 +602,7 @@ function update_estimate!(estim::UnscentedKalmanFilter{NT}, u, ym, d) where NT<:
     X̂_cor[:, nx̂+2:end] .-= γ_sqrt_P̂_cor
     X̂_next = X̂_cor
     for j in axes(X̂_next, 2)
-        X̂_next[:, j] = @views f̂(estim, estim.model, X̂_cor[:, j], u, d)
+        @views f̂!(X̂_next[:, j], estim, estim.model, X̂_cor[:, j], u, d)
     end
     x̂_next = mul!(x̂, X̂_next, m̂)
     X̄_next = X̂_next
@@ -757,9 +759,13 @@ automatically computes the Jacobians:
 ```
 The matrix ``\mathbf{Ĥ^m}`` is the rows of ``\mathbf{Ĥ}`` that are measured outputs.
 """
-function update_estimate!(estim::ExtendedKalmanFilter, u, ym, d=empty(estim.x̂))
-    F̂ = ForwardDiff.jacobian(x̂ -> f̂(estim, estim.model, x̂, u, d), estim.x̂)
-    Ĥ = ForwardDiff.jacobian(x̂ -> ĥ(estim, estim.model, x̂, d), estim.x̂)
+function update_estimate!(
+    estim::ExtendedKalmanFilter{NT}, u, ym, d=empty(estim.x̂)
+) where NT<:Real
+    model = estim.model
+    x̂next, ŷ = Vector{NT}(undef, estim.nx̂), Vector{NT}(undef, model.ny)
+    F̂ = ForwardDiff.jacobian((x̂next, x̂) -> f̂!(x̂next, estim, model, x̂, u, d), x̂next, estim.x̂)
+    Ĥ = ForwardDiff.jacobian((ŷ, x̂)     -> ĥ!(ŷ, estim, model, x̂, d), ŷ, estim.x̂)
     return update_estimate_kf!(estim, u, ym, d, F̂, Ĥ[estim.i_ym, :], estim.P̂, estim.x̂)
 end
 
@@ -790,7 +796,7 @@ function validate_kfcov(nym, nx̂, Q̂, R̂, P̂0=nothing)
 end
 
 """
-    update_estimate_kf!(estim, u, ym, d, Â, Ĉm, P̂, x̂=nothing)
+    update_estimate_kf!(estim::StateEstimator, u, ym, d, Â, Ĉm, P̂, x̂=nothing)
 
 Update time-varying/extended Kalman Filter estimates with augmented `Â` and `Ĉm` matrices.
 
@@ -801,16 +807,22 @@ The implementation uses in-place operations and explicit factorization to reduce
 allocations. See e.g. [`KalmanFilter`](@ref) docstring for the equations. If `isnothing(x̂)`,
 only the covariance `P̂` is updated.
 """
-function update_estimate_kf!(estim, u, ym, d, Â, Ĉm, P̂, x̂=nothing)
+function update_estimate_kf!(
+    estim::StateEstimator{NT}, u, ym, d, Â, Ĉm, P̂, x̂=nothing
+) where NT<:Real
     Q̂, R̂, M̂ = estim.Q̂, estim.R̂, estim.M̂
     mul!(M̂, P̂, Ĉm')
     rdiv!(M̂, cholesky!(Hermitian(Ĉm * P̂ * Ĉm' .+ R̂)))
     if !isnothing(x̂)
         mul!(estim.K̂, Â, M̂)
-        ŷm = @views ĥ(estim, estim.model, x̂, d)[estim.i_ym]
+        x̂next, ŷ = Vector{NT}(undef, estim.nx̂), Vector{NT}(undef, estim.model.ny)
+        ĥ!(ŷ, estim, estim.model, x̂, d)
+        ŷm = @views ŷ[estim.i_ym]
         v̂  = ŷm
         v̂ .= ym .- ŷm
-        x̂ .= f̂(estim, estim.model, x̂, u, d) .+ mul!(x̂, estim.K̂, v̂)
+        f̂!(x̂next, estim, estim.model, x̂, u, d)
+        mul!(x̂next, estim.K̂, v̂, 1, 1)
+        estim.x̂ .= x̂next
     end
     P̂.data .= Â * (P̂ .- M̂ * Ĉm * P̂) * Â' .+ Q̂ # .data is necessary for Hermitians
     return nothing

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -567,7 +567,7 @@ function update_estimate!(estim::UnscentedKalmanFilter{NT}, u, ym, d) where NT<:
     nym, nx̂, nσ = estim.nym, estim.nx̂, estim.nσ
     γ, m̂, Ŝ = estim.γ, estim.m̂, estim.Ŝ
     # --- initialize matrices ---
-    X̂  = Matrix{NT}(undef, nx̂, nσ)
+    X̂, X̂_next = Matrix{NT}(undef, nx̂, nσ), Matrix{NT}(undef, nx̂, nσ)
     ŷm = Vector{NT}(undef, nym)
     ŷ  = Vector{NT}(undef, estim.model.ny)
     Ŷm = Matrix{NT}(undef, nym, nσ)
@@ -600,7 +600,7 @@ function update_estimate!(estim::UnscentedKalmanFilter{NT}, u, ym, d) where NT<:
     X̂_cor .= x̂_cor
     X̂_cor[:, 2:nx̂+1]   .+= γ_sqrt_P̂_cor
     X̂_cor[:, nx̂+2:end] .-= γ_sqrt_P̂_cor
-    X̂_next = X̂_cor
+    X̂_next = similar(X̂_cor)
     for j in axes(X̂_next, 2)
         @views f̂!(X̂_next[:, j], estim, estim.model, X̂_cor[:, j], u, d)
     end

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -138,7 +138,7 @@ function getinfo(estim::MovingHorizonEstimator{NT}) where NT<:Real
     for i=1:Nk
         d0 = @views D[(1 + nd*(i-1)):(nd*i)] # operating point already removed in estim.D
         x̂  = @views X̂[(1 + nx̂*(i-1)):(nx̂*i)]
-        ĥ!(Ŷ[(1 + ny*(i-1)):(ny*i)], estim, model, x̂, d0) 
+        @views ĥ!(Ŷ[(1 + ny*(i-1)):(ny*i)], estim, model, x̂, d0)
         Ŷ[(1 + ny*(i-1)):(ny*i)] .+= model.yop
     end
     Ŷm = Ym - V̂

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -137,8 +137,9 @@ function getinfo(estim::MovingHorizonEstimator{NT}) where NT<:Real
     Ŷ = Vector{NT}(undef, ny*Nk)
     for i=1:Nk
         d0 = @views D[(1 + nd*(i-1)):(nd*i)] # operating point already removed in estim.D
-        x̂ = @views X̂[(1 + nx̂*(i-1)):(nx̂*i)]
-        Ŷ[(1 + ny*(i-1)):(ny*i)] = ĥ(estim, model, x̂, d0) + model.yop
+        x̂  = @views X̂[(1 + nx̂*(i-1)):(nx̂*i)]
+        ĥ!(Ŷ[(1 + ny*(i-1)):(ny*i)], estim, model, x̂, d0) 
+        Ŷ[(1 + ny*(i-1)):(ny*i)] .+= model.yop
     end
     Ŷm = Ym - V̂
     info[:Ŵ] = estim.Ŵ[1:Nk*nŵ]
@@ -326,10 +327,11 @@ function update_cov!(P̂, estim::MovingHorizonEstimator, ::LinModel, u, ym, d)
     return update_estimate_kf!(estim, u, ym, d, estim.Â, estim.Ĉ[estim.i_ym, :], P̂)
 end
 "Update it with the `ExtendedKalmanFilter` if model is not a `LinModel`."
-function update_cov!(P̂, estim::MovingHorizonEstimator, ::SimModel, u, ym, d) 
+function update_cov!(P̂, estim::MovingHorizonEstimator, model::SimModel, u, ym, d) 
     # TODO: also support UnscentedKalmanFilter
-    F̂ = ForwardDiff.jacobian(x̂ -> f̂(estim, estim.model, x̂, u, d), estim.x̂)
-    Ĥ = ForwardDiff.jacobian(x̂ -> ĥ(estim, estim.model, x̂, d), estim.x̂)
+    x̂next, ŷ = similar(estim.x̂), similar(model.yop)
+    F̂ = ForwardDiff.jacobian((x̂next, x̂) -> f̂!(x̂next, estim, estim.model, x̂, u, d), x̂next, estim.x̂)
+    Ĥ = ForwardDiff.jacobian((ŷ, x̂)     -> ĥ!(ŷ, estim, estim.model, x̂, d), ŷ, estim.x̂)
     return update_estimate_kf!(estim, u, ym, d, F̂, Ĥ[estim.i_ym, :],  P̂)
 end
 
@@ -394,16 +396,22 @@ function predict!(
     V̂, X̂, estim::MovingHorizonEstimator, model::SimModel, Z̃::Vector{T}
 ) where {T<:Real}
     Nk = estim.Nk[]
-    nu, nd, nx̂, nŵ, nym = model.nu, model.nd, estim.nx̂, estim.nx̂, estim.nym
+    nu, nd, ny, nx̂, nŵ, nym = model.nu, model.nd, model.ny, estim.nx̂, estim.nx̂, estim.nym
     nx̃ = !isinf(estim.C) + nx̂
+    # TODO: avoid these two allocations if possible:
+    ŷ, x̂next = Vector{T}(undef, ny), Vector{T}(undef, nx̂)
     x̂ = @views Z̃[nx̃-nx̂+1:nx̃]
     for j=1:Nk
         u  = @views estim.U[ (1 + nu  * (j-1)):(nu*j)]
         ym = @views estim.Ym[(1 + nym * (j-1)):(nym*j)]
         d  = @views estim.D[ (1 + nd  * (j-1)):(nd*j)]
         ŵ  = @views Z̃[(1 + nx̃ + nŵ*(j-1)):(nx̃ + nŵ*j)]
-        V̂[(1 + nym*(j-1)):(nym*j)] = ym - ĥ(estim, model, x̂, d)[estim.i_ym]
-        X̂[(1 + nx̂ *(j-1)):(nx̂ *j)] = f̂(estim, model, x̂, u, d) + ŵ
+        ĥ!(ŷ, estim, model, x̂, d)
+        ŷm = @views ŷ[estim.i_ym]
+        V̂[(1 + nym*(j-1)):(nym*j)] .= ym .- ŷm
+        f̂!(x̂next, estim, model, x̂, u, d)
+        x̂next .+= ŵ
+        X̂[(1 + nx̂ *(j-1)):(nx̂ *j)] = x̂next
         x̂ = @views X̂[(1 + nx̂*(j-1)):(nx̂*j)]
     end
     return V̂, X̂

--- a/src/model/nonlinmodel.jl
+++ b/src/model/nonlinmodel.jl
@@ -23,9 +23,9 @@ struct NonLinModel{NT<:Real, F<:Function, H<:Function} <: SimModel{NT}
 end
 
 @doc raw"""
-    NonLinModel{NT}(f!::Function, h!::Function, Ts, nu, nx, ny, nd=0)
+    NonLinModel{NT}(f::Function, h::Function, Ts, nu, nx, ny, nd=0)
 
-Construct a nonlinear model from discrete-time state-space functions `f!` and `h!`.
+Construct a nonlinear model from discrete-time state-space functions `f` and `h`.
 
 The state update ``\mathbf{f}`` and output ``\mathbf{h}`` functions are defined as :
 ```math
@@ -45,7 +45,7 @@ Nonlinear continuous-time state-space functions are not supported for now. In su
 manually call a differential equation solver in `f` (see [Manual](@ref man_nonlin)).
 
 !!! warning
-    `f!` and `h!` must be pure Julia functions to use the model in [`NonLinMPC`](@ref),
+    `f` and `h` must be pure Julia functions to use the model in [`NonLinMPC`](@ref),
     [`ExtendedKalmanFilter`](@ref), [`MovingHorizonEstimator`](@ref) and [`linearize`](@ref).
 
 See also [`LinModel`](@ref).
@@ -61,82 +61,75 @@ Discrete-time nonlinear model with a sample time Ts = 10.0 s and:
 ```
 """
 function NonLinModel{NT}(
-    f!::Function, h!::Function, Ts::Real, nu::Int, nx::Int, ny::Int, nd::Int=0
+    f::Function, h::Function, Ts::Real, nu::Int, nx::Int, ny::Int, nd::Int=0
 ) where {NT<:Real}
-    iscontinous = validate_fcts(NT, f!, h!)
-    if iscontinous
-        fc! = f!
-        f! = let nx=nx, Ts=Ts, NT=NT
-            ẋ = zeros(NT, nx)
-            xterm = zeros(NT, nx)
-            k1, k2, k3, k4 = zeros(NT, nx), zeros(NT, nx), zeros(NT, nx), zeros(NT, nx)
-            function rk4!(x, u, d)
-                xterm .= x
-                fc!(ẋ, xterm, u, d)
-                k1 .= ẋ
-                xterm .= @. x + k1 * Ts/2
-                fc!(ẋ, xterm, u, d)
-                k2 .= ẋ 
-                xterm .= @. x + k2 * Ts/2
-                fc!(ẋ, xterm, u, d)
-                k3 .= ẋ
-                xterm .= @. x + k3 * Ts
-                fc!(ẋ, xterm, u, d)
-                k4 .= ẋ
-                x .+= @. (k1 + 2k2 + 2k3 + k4)*Ts/6
-                return x
-            end
-            rk4!
-        end
+    ismutating_f = validate_f(NT, f)
+    ismutating_h = validate_h(NT, h)
+    f! = let f = f
+        ismutating_f ? f : (xnext, x, u, d) -> xnext .= f(x, u, d)
+    end
+    h! = let h = h
+        ismutating_h ? h : (y, x, d) -> y .= h(x, d)
     end
     F, H = getFuncTypes(f!, h!)
     return NonLinModel{NT, F, H}(f!, h!, Ts, nu, nx, ny, nd)
 end
 
 function NonLinModel(
-    f!::Function, h!::Function, Ts::Real, nu::Int, nx::Int, ny::Int, nd::Int=0
+    f::Function, h::Function, Ts::Real, nu::Int, nx::Int, ny::Int, nd::Int=0
 )
-    return NonLinModel{Float64}(f!, h!, Ts, nu, nx, ny, nd)
+    return NonLinModel{Float64}(f, h, Ts, nu, nx, ny, nd)
 end
 
-getFuncTypes(f!::F, h!::H) where {F<:Function, H<:Function} = F, H
+getFuncTypes(f::F, h::H) where {F<:Function, H<:Function} = F, H
 
 
 """
-    validate_fcts(NT, f!, h!) -> iscontinuous
+    validate_f(NT, f) -> ismutating
 
-Validate `f!` and `h!` function argument signatures and return `true` if `f!` is continuous.
+Validate `f` function argument signature and return `true` if it is mutating.
 """
-function validate_fcts(NT, f!, h!)
-    isdiscrete = hasmethod(f!,
-        Tuple{Vector{NT}, Vector{NT}, Vector{NT}}
-    )
-    iscontinuous = hasmethod(f!,
-        Tuple{Vector{NT}, Vector{NT}, Vector{NT}, Vector{NT}}
-    )
-    if !isdiscrete && !iscontinuous
-        println(isdiscrete)
-        println(iscontinuous)
-        error("state function has no method with type signature "*
-              "f!(x::Vector{$(NT)}, u::Vector{$(NT)}, d::Vector{$(NT)}) or "*
-              "f!(ẋ::Vector{$(NT)}, x::Vector{$(NT)}, u::Vector{$(NT)}, d::Vector{$(NT)})")
+function validate_f(NT, f)
+    ismutating = hasmethod(f, Tuple{Vector{NT}, Vector{NT}, Vector{NT}, Vector{NT}})
+    if !(ismutating || hasmethod(f, Tuple{Vector{NT}, Vector{NT}, Vector{NT}}))
+        error(
+            "the state function has no method with type signature "*
+            "f(x::Vector{$(NT)}, u::Vector{$(NT)}, d::Vector{$(NT)}) or mutating form "*
+            "f!(xnext::Vector{$(NT)}, x::Vector{$(NT)}, u::Vector{$(NT)}, d::Vector{$(NT)})"
+        )
     end
-    hargsvalid = hasmethod(h!, Tuple{Vector{NT}, Vector{NT}, Vector{NT}})
-    if !hargsvalid
-        error("output function has no method with type signature "*
-              "h!(y::Vector{$(NT)}, x::Vector{$(NT)}, d::Vector{$(NT)})")
+    return ismutating
+end
+
+"""
+    validate_h(NT, h) -> ismutating
+
+Validate `h` function argument signature and return `true` if it is mutating.
+"""
+function validate_h(NT, h)
+    ismutating = hasmethod(h, Tuple{Vector{NT}, Vector{NT}, Vector{NT}})
+    if !(ismutating || hasmethod(h, Tuple{Vector{NT}, Vector{NT}}))
+        error(
+            "the output function has no method with type signature "*
+            "h(x::Vector{$(NT)}, d::Vector{$(NT)}) or mutating form "*
+            "h!(y::Vector{$(NT)}, x::Vector{$(NT)}, d::Vector{$(NT)})"
+        )
     end
-    return iscontinuous
+    return ismutating
 end
 
 "Do nothing if `model` is a [`NonLinModel`](@ref)."
 steadystate!(::SimModel, _ , _ ) = nothing
 
 
+
+
+
 "Call ``\\mathbf{f!(x, u, d)}`` with `model.f!` function for [`NonLinModel`](@ref)."
-f!(x, model::NonLinModel, u, d) = model.f!(x, u, d)
+f!(xnext, model::NonLinModel, x, u, d) = model.f!(xnext, x, u, d)
 
 "Call ``\\mathbf{h!(y, x, d)}`` with `model.h` function for [`NonLinModel`](@ref)."
 h!(y, model::NonLinModel, x, d) = model.h!(y, x, d)
 
 typestr(model::NonLinModel) = "nonlinear"
+

--- a/src/model/nonlinmodel.jl
+++ b/src/model/nonlinmodel.jl
@@ -122,13 +122,10 @@ end
 steadystate!(::SimModel, _ , _ ) = nothing
 
 
-
-
-
-"Call ``\\mathbf{f!(x, u, d)}`` with `model.f!` function for [`NonLinModel`](@ref)."
+"Call `f!(xnext, x, u, d)` with `model.f!` method for [`NonLinModel`](@ref)."
 f!(xnext, model::NonLinModel, x, u, d) = model.f!(xnext, x, u, d)
 
-"Call ``\\mathbf{h!(y, x, d)}`` with `model.h` function for [`NonLinModel`](@ref)."
+"Call `h!(y, x, d)` with `model.h` method for [`NonLinModel`](@ref)."
 h!(y, model::NonLinModel, x, d) = model.h!(y, x, d)
 
 typestr(model::NonLinModel) = "nonlinear"

--- a/src/model/nonlinmodel.jl
+++ b/src/model/nonlinmodel.jl
@@ -121,10 +121,10 @@ function validate_fcts(NT, f!, h!)
               "f!(x::Vector{$(NT)}, u::Vector{$(NT)}, d::Vector{$(NT)}) or "*
               "f!(ẋ::Vector{$(NT)}, x::Vector{$(NT)}, u::Vector{$(NT)}, d::Vector{$(NT)})")
     end
-    hargsvalid = hasmethod(h!,Tuple{Vector{NT}, Vector{NT}})
+    hargsvalid = hasmethod(h!, Tuple{Vector{NT}, Vector{NT}, Vector{NT}})
     if !hargsvalid
         error("output function has no method with type signature "*
-              "h(x::Vector{$(NT)}, d::Vector{$(NT)})")
+              "h!(y::Vector{$(NT)}, x::Vector{$(NT)}, d::Vector{$(NT)})")
     end
     return iscontinuous
 end
@@ -136,7 +136,7 @@ steadystate!(::SimModel, _ , _ ) = nothing
 "Call ``\\mathbf{f!(x, u, d)}`` with `model.f!` function for [`NonLinModel`](@ref)."
 f!(x, model::NonLinModel, u, d) = model.f!(x, u, d)
 
-"Call ``\\mathbf{h(x, d)}`` with `model.h` function for [`NonLinModel`](@ref)."
-h(model::NonLinModel, x, d) = model.h!(x, d)
+"Call ``\\mathbf{h!(y, x, d)}`` with `model.h` function for [`NonLinModel`](@ref)."
+h!(y, model::NonLinModel, x, d) = model.h!(y, x, d)
 
 typestr(model::NonLinModel) = "nonlinear"

--- a/src/model/nonlinmodel.jl
+++ b/src/model/nonlinmodel.jl
@@ -130,3 +130,19 @@ h!(y, model::NonLinModel, x, d) = model.h!(y, x, d)
 
 typestr(model::NonLinModel) = "nonlinear"
 
+function rk4!(x, u, d)
+    xterm .= x
+    fc!(ẋ, xterm, u, d)
+    k1 .= ẋ
+    xterm .= @. x + k1 * Ts/2
+    fc!(ẋ, xterm, u, d)
+    k2 .= ẋ 
+    xterm .= @. x + k2 * Ts/2
+    fc!(ẋ, xterm, u, d)
+    k3 .= ẋ
+    xterm .= @. x + k3 * Ts
+    fc!(ẋ, xterm, u, d)
+    k4 .= ẋ
+    x .+= @. (k1 + 2k2 + 2k3 + k4)*Ts/6
+    return x
+end

--- a/src/model/nonlinmodel.jl
+++ b/src/model/nonlinmodel.jl
@@ -23,7 +23,8 @@ struct NonLinModel{NT<:Real, F<:Function, H<:Function} <: SimModel{NT}
 end
 
 @doc raw"""
-    NonLinModel{NT}(f::Function, h::Function, Ts, nu, nx, ny, nd=0)
+    NonLinModel{NT}( f::Function,  h::Function, Ts, nu, nx, ny, nd=0)
+    NonLinModel{NT}(f!::Function, h!::Function, Ts, nu, nx, ny, nd=0)
 
 Construct a nonlinear model from discrete-time state-space functions `f` and `h`.
 
@@ -34,6 +35,14 @@ The state update ``\mathbf{f}`` and output ``\mathbf{h}`` functions are defined 
     \mathbf{y}(k)   &= \mathbf{h}\Big( \mathbf{x}(k), \mathbf{d}(k) \Big)
     \end{aligned}
 ```
+They can be specified in two forms:
+
+- non-mutating functions (out-of-place): they must be defined as `f(x, u, d) -> xnext` and
+  `h(x, d) -> y`
+- mutating functions (in-place): they must be defined as `f!(xnext, x, u, d) -> nothing` and
+  `h!(y, x, d) -> nothing`. This syntax reduces the allocations and potentially the 
+  computational burden as well.
+  
 `Ts` is the sampling time in second. `nu`, `nx`, `ny` and `nd` are the respective number of 
 manipulated inputs, states, outputs and measured disturbances. The optional parameter `NT`
 explicitly specifies the number type of vectors (default to `Float64`).

--- a/src/plot_sim.jl
+++ b/src/plot_sim.jl
@@ -129,7 +129,7 @@ function sim!(
         U_data[:, i]  = u
         D_data[:, i]  = d
         X_data[:, i]  = plant.x
-        updatestate!(plant, u, d); 
+        x = updatestate!(plant, u, d)
     end
     return SimResult(plant, T_data, Y_data, U_data, Y_data, 
                      U_data, U_data, U_data, D_data, X_data, X_data)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,3 +1,4 @@
+#=
 sys = [ 
     tf(1.90, [1800, 1]) tf(1.90, [1800, 1]);
     tf(-0.74,[800, 1])  tf(0.74, [800, 1]) 
@@ -98,3 +99,4 @@ end
 empc = setconstraint!(NonLinMPC(nlmodel, Mwt=[0, 0], Hp=10, Cwt=Inf, Ewt=1, JE=JE), ymin=[45, -Inf])
 u = empc()
 sim!(empc, 3)
+=#

--- a/src/sim_model.jl
+++ b/src/sim_model.jl
@@ -144,7 +144,7 @@ julia> x = updatestate!(model, [1])
 """
 function updatestate!(model::SimModel, u, d=empty(model.x))
     validate_args(model::SimModel, u, d)
-    model.x[:] = f(model, model.x, u - model.uop, d - model.dop)
+    model.x .= f!(model.x, model, u - model.uop, d - model.dop)
     return model.x
 end
 

--- a/src/sim_model.jl
+++ b/src/sim_model.jl
@@ -144,7 +144,7 @@ julia> x = updatestate!(model, [1])
 """
 function updatestate!(model::SimModel, u, d=empty(model.x))
     validate_args(model::SimModel, u, d)
-    model.x .= f!(model.x, model, u - model.uop, d - model.dop)
+    f!(model.x, model, u - model.uop, d - model.dop)
     return model.x
 end
 
@@ -164,7 +164,11 @@ julia> y = evaloutput(model)
  20.0
 ```
 """
-evaloutput(model::SimModel, d=empty(model.x)) = h(model, model.x, d - model.dop) + model.yop
+function evaloutput(model::SimModel{NT}, d=empty(model.x)) where NT <: Real
+    y = Vector{NT}(undef, model.ny)
+    h!(y, model, model.x, d - model.dop) + model.yop
+    return y
+end
 
 """
     validate_args(model::SimModel, u, d)

--- a/src/state_estim.jl
+++ b/src/state_estim.jl
@@ -66,19 +66,4 @@ Evaluate [`StateEstimator`](@ref) output `ŷ` from measured disturbance `d` and
 Second argument is ignored, except for [`InternalModel`](@ref).
 """
 evalŷ(estim::StateEstimator, _ , d) = evaloutput(estim, d)
-
-@doc raw"""
-    evalŷ(estim::InternalModel, ym, d) -> ŷ
-
-Get [`InternalModel`](@ref) output `ŷ` from current measured outputs `ym` and dist. `d`.
-
-[`InternalModel`](@ref) estimator needs current measured outputs ``\mathbf{y^m}(k)`` to 
-estimate its outputs ``\mathbf{ŷ}(k)``, since the strategy imposes that 
-``\mathbf{ŷ^m}(k) = \mathbf{y^m}(k)`` is always true.
-"""
-function evalŷ(estim::InternalModel, ym, d)
-    ŷ = h(estim.model, estim.x̂d, d - estim.model.dop) + estim.model.yop
-    ŷ[estim.i_ym] = ym
-    return ŷ
-end
     

--- a/test/test_predictive_control.jl
+++ b/test/test_predictive_control.jl
@@ -462,11 +462,12 @@ end
     @test ForwardDiff.gradient(g_Ymax_end, [1.0, 1.0]) ≈ [0.0, 0.0]
     linmodel3 = LinModel{Float32}(0.5*ones(1,1), ones(1,1), ones(1,1), zeros(1,0), zeros(1,0), 1.0)
     nmpc6  = NonLinMPC(linmodel3, Hp=10)
-    moveinput!(nmpc6, [0]) ≈ [0.0]
+    @test moveinput!(nmpc6, [0]) ≈ [0.0]
     nonlinmodel2 = NonLinModel{Float32}(f, h, 3000.0, 1, 2, 1, 1)
     nmpc7  = NonLinMPC(nonlinmodel2, Hp=10)
-    nonlinmodel2.h(Float32[0,0], Float32[0])
-    moveinput!(nmpc7, [0], [0]) ≈ [0.0]
+    y = similar(nonlinmodel2.yop)
+    nonlinmodel2.h!(y, Float32[0,0], Float32[0])
+    @test moveinput!(nmpc7, [0], [0]) ≈ [0.0]
 end
 
 @testset "NonLinMPC step disturbance rejection" begin

--- a/test/test_sim_model.jl
+++ b/test/test_sim_model.jl
@@ -112,8 +112,11 @@ end
     @test nonlinmodel1.nu == 2
     @test nonlinmodel1.nd == 0
     @test nonlinmodel1.ny == 2
-    @test nonlinmodel1.f!([0,0],[0,0],[0,0],[1]) ≈ zeros(2,)
-    @test nonlinmodel1.h!([0,0],[0,0],[1]) ≈ zeros(2,)
+    xnext, y = similar(nonlinmodel1.x), similar(nonlinmodel1.yop)
+    nonlinmodel1.f!(xnext,[0,0],[0,0],[1])
+    @test xnext ≈ zeros(2,)
+    nonlinmodel1.h!(y,[0,0],[1])
+    @test y ≈ zeros(2,)
 
     linmodel2 = LinModel(sys,Ts,i_d=[3])
     f2(x,u,d) = linmodel2.A*x + linmodel2.Bu*u + linmodel2.Bd*d
@@ -124,8 +127,11 @@ end
     @test nonlinmodel2.nu == 2
     @test nonlinmodel2.nd == 1
     @test nonlinmodel2.ny == 2
-    @test nonlinmodel2.f!([0,0,0,0],[0,0,0,0],[0,0],[0]) ≈ zeros(4,)
-    @test nonlinmodel2.h!([0,0],[0,0,0,0],[0]) ≈ zeros(2,)
+    xnext, y = similar(nonlinmodel2.x), similar(nonlinmodel2.yop)
+    nonlinmodel2.f!(xnext,[0,0,0,0],[0,0],[0])
+    @test xnext ≈ zeros(4,)
+    nonlinmodel2.h!(y,[0,0,0,0],[0])
+    @test y ≈ zeros(2,)
 
     nonlinemodel3 = NonLinModel{Float32}(f2,h2,Ts,2,4,2,1)
     @test isa(nonlinemodel3, NonLinModel{Float32})

--- a/test/test_sim_model.jl
+++ b/test/test_sim_model.jl
@@ -112,8 +112,8 @@ end
     @test nonlinmodel1.nu == 2
     @test nonlinmodel1.nd == 0
     @test nonlinmodel1.ny == 2
-    @test nonlinmodel1.f([0,0],[0,0],[1]) ≈ zeros(2,)
-    @test nonlinmodel1.h([0,0],[1]) ≈ zeros(2,)
+    @test nonlinmodel1.f!([0,0],[0,0],[0,0],[1]) ≈ zeros(2,)
+    @test nonlinmodel1.h!([0,0],[0,0],[1]) ≈ zeros(2,)
 
     linmodel2 = LinModel(sys,Ts,i_d=[3])
     f2(x,u,d) = linmodel2.A*x + linmodel2.Bu*u + linmodel2.Bd*d
@@ -124,8 +124,8 @@ end
     @test nonlinmodel2.nu == 2
     @test nonlinmodel2.nd == 1
     @test nonlinmodel2.ny == 2
-    @test nonlinmodel2.f([0,0,0,0],[0,0],[0]) ≈ zeros(4,)
-    @test nonlinmodel2.h([0,0,0,0],[0]) ≈ zeros(2,)
+    @test nonlinmodel2.f!([0,0,0,0],[0,0,0,0],[0,0],[0]) ≈ zeros(4,)
+    @test nonlinmodel2.h!([0,0],[0,0,0,0],[0]) ≈ zeros(2,)
 
     nonlinemodel3 = NonLinModel{Float32}(f2,h2,Ts,2,4,2,1)
     @test isa(nonlinemodel3, NonLinModel{Float32})


### PR DESCRIPTION
Added: support with mutating `f!`and `h!` functions to reduce the allocations. This change is backward compatible since non-mutating functions are also supported and the syntax is identical to previous version of the package.