### PR TITLE
Reduce allocations by avoiding `empty` for default `d` argument

### DIFF
--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -79,7 +79,7 @@ end
 
 
 @doc raw"""
-    initstate!(estim::StateEstimator, u, ym, d=[]) -> x̂
+    initstate!(estim::StateEstimator, u, ym, d=estim.model.dop) -> x̂
 
 Init `estim.x̂0` states from current inputs `u`, measured outputs `ym` and disturbances `d`.
 
@@ -111,7 +111,7 @@ julia> evaloutput(estim) ≈ y
 true
 ```
 """
-function initstate!(estim::StateEstimator, u, ym, d=empty(estim.x̂0))
+function initstate!(estim::StateEstimator, u, ym, d=estim.model.dop)
     # --- validate arguments ---
     validate_args(estim, u, ym, d)
     # --- init state estimate ----
@@ -161,7 +161,7 @@ Left `estim.x̂0` estimate unchanged if `model` is not a [`LinModel`](@ref).
 init_estimate!(::StateEstimator, ::SimModel, _ , _ , _ ) = nothing
 
 @doc raw"""
-    evaloutput(estim::StateEstimator, d=[]) -> ŷ
+    evaloutput(estim::StateEstimator, d=estim.model.dop) -> ŷ
 
 Evaluate `StateEstimator` outputs `ŷ` from `estim.x̂0` states and disturbances `d`.
 
@@ -176,7 +176,7 @@ julia> ŷ = evaloutput(kf)
  20.0
 ```
 """
-function evaloutput(estim::StateEstimator{NT}, d=empty(estim.x̂0)) where NT <: Real
+function evaloutput(estim::StateEstimator{NT}, d=estim.model.dop) where NT <: Real
     validate_args(estim.model, d)
     ŷ0 = Vector{NT}(undef, estim.model.ny)
     d0 = d - estim.model.dop
@@ -187,10 +187,10 @@ function evaloutput(estim::StateEstimator{NT}, d=empty(estim.x̂0)) where NT <: 
 end
 
 "Functor allowing callable `StateEstimator` object as an alias for `evaloutput`."
-(estim::StateEstimator)(d=empty(estim.x̂0)) = evaloutput(estim, d)
+(estim::StateEstimator)(d=estim.model.dop) = evaloutput(estim, d)
 
 @doc raw"""
-    updatestate!(estim::StateEstimator, u, ym, d=[]) -> x̂
+    updatestate!(estim::StateEstimator, u, ym, d=estim.model.dop) -> x̂
 
 Update `estim.x̂0` estimate with current inputs `u`, measured outputs `ym` and dist. `d`. 
 
@@ -207,7 +207,7 @@ julia> x̂ = updatestate!(kf, [1], [0]) # x̂[2] is the integrator state (nint_y
  0.0
 ```
 """
-function updatestate!(estim::StateEstimator, u, ym, d=empty(estim.x̂0))
+function updatestate!(estim::StateEstimator, u, ym, d=estim.model.dop)
     validate_args(estim, u, ym, d)
     u0, ym0, d0 = remove_op!(estim, u, ym, d)
     x̂0next = update_estimate!(estim, u0, ym0, d0)

--- a/src/predictive_control.jl
+++ b/src/predictive_control.jl
@@ -3,7 +3,7 @@ Abstract supertype of all predictive controllers.
 
 ---
 
-    (mpc::PredictiveController)(ry, d=[]; kwargs...) -> u
+    (mpc::PredictiveController)(ry, d=mpc.estim.model.dop; kwargs...) -> u
 
 Functor allowing callable `PredictiveController` object as an alias for [`moveinput!`](@ref).
 
@@ -42,7 +42,7 @@ end
 "Functor allowing callable `PredictiveController` object as an alias for `moveinput!`."
 function (mpc::PredictiveController)(
     ry::Vector = mpc.estim.model.yop, 
-    d ::Vector = empty(mpc.estim.x̂0);
+    d ::Vector = mpc.estim.model.dop;
     kwargs...
 )
     return moveinput!(mpc, ry, d; kwargs...)

--- a/src/sim_model.jl
+++ b/src/sim_model.jl
@@ -5,7 +5,7 @@ Abstract supertype of [`LinModel`](@ref) and [`NonLinModel`](@ref) types.
 
 ---
 
-    (model::SimModel)(d=[]) -> y
+    (model::SimModel)(d=model.dop) -> y
 
 Functor allowing callable `SimModel` object as an alias for [`evaloutput`](@ref).
 
@@ -160,7 +160,7 @@ end
 detailstr(model::SimModel) = ""
 
 @doc raw"""
-    initstate!(model::SimModel, u, d=[]) -> x
+    initstate!(model::SimModel, u, d=model.dop) -> x
 
 Init `model.x0` with manipulated inputs `u` and measured disturbances `d` steady-state.
 
@@ -182,7 +182,7 @@ julia> x ≈ updatestate!(model, u)
 true
 ```
 """
-function initstate!(model::SimModel, u, d=empty(model.x0))
+function initstate!(model::SimModel, u, d=model.dop)
     validate_args(model::SimModel, d, u)
     u0, d0 = u - model.uop, d - model.dop
     steadystate!(model, u0, d0)
@@ -191,7 +191,7 @@ function initstate!(model::SimModel, u, d=empty(model.x0))
 end
 
 """
-    updatestate!(model::SimModel, u, d=[]) -> x
+    updatestate!(model::SimModel, u, d=model.dop) -> x
 
 Update `model.x0` states with current inputs `u` and measured disturbances `d`.
 
@@ -204,7 +204,7 @@ julia> x = updatestate!(model, [1])
  1.0
 ```
 """
-function updatestate!(model::SimModel{NT}, u, d=empty(model.x0)) where NT <: Real
+function updatestate!(model::SimModel{NT}, u, d=model.dop) where NT <: Real
     validate_args(model::SimModel, d, u)
     xnext0 = Vector{NT}(undef, model.nx)
     u0, d0 = u - model.uop, d - model.dop
@@ -217,7 +217,7 @@ function updatestate!(model::SimModel{NT}, u, d=empty(model.x0)) where NT <: Rea
 end
 
 """
-    evaloutput(model::SimModel, d=[]) -> y
+    evaloutput(model::SimModel, d=model.dop) -> y
 
 Evaluate `SimModel` outputs `y` from `model.x0` states and measured disturbances `d`.
 
@@ -232,7 +232,7 @@ julia> y = evaloutput(model)
  20.0
 ```
 """
-function evaloutput(model::SimModel{NT}, d=empty(model.x0)) where NT <: Real
+function evaloutput(model::SimModel{NT}, d=model.dop) where NT <: Real
     validate_args(model, d)
     y0 = Vector{NT}(undef, model.ny)
     d0 = d - model.dop
@@ -262,7 +262,7 @@ to_mat(A::Real, dims...) = fill(A, dims)
 
 
 "Functor allowing callable `SimModel` object as an alias for `evaloutput`."
-(model::SimModel)(d=empty(model.x0)) = evaloutput(model::SimModel, d)
+(model::SimModel)(d=model.dop) = evaloutput(model::SimModel, d)
 
 include("model/linmodel.jl")
 include("model/solver.jl")

--- a/src/state_estim.jl
+++ b/src/state_estim.jl
@@ -3,7 +3,7 @@ Abstract supertype of all state estimators.
 
 ---
 
-    (estim::StateEstimator)(d=[]) -> ŷ
+    (estim::StateEstimator)(d=estim.model.dop) -> ŷ
 
 Functor allowing callable `StateEstimator` object as an alias for [`evaloutput`](@ref).
 


### PR DESCRIPTION
I now use `model.dop` as default `d` value in all the methods. This does not allocate. As a minor drawback, no error is raised if the user construct a controller with a feedforward compensation but does not provide a `d` argument in `moveinput!` (an error was raised before).