### PR TITLE
added: doc correction and reduce allocations for all Kalman filters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
 authors = ["Francis Gagnon"]
-version = "0.23.0"
+version = "0.23.1"
 
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ for more detailed examples.
 - [x] bumpless manual to automatic transfer for control with a proper initial estimate
 - [ ] estimators in two possible forms:
   - [x] predictor (or delayed) form to reduce computational load
-  - [ ] filter (or current) form to improve accuracy and robustness
+  - [x] filter (or current) form to improve accuracy and robustness
 - [x] moving horizon estimator in two formulations:
   - [x] linear plant models (quadratic optimization)
   - [x] nonlinear plant models (nonlinear optimization)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ for more detailed examples.
   - [x] manipulated inputs
   - [x] measured outputs
 - [x] bumpless manual to automatic transfer for control with a proper initial estimate
-- [ ] estimators in two possible forms:
+- [x] estimators in two possible forms:
   - [x] filter (or current) form to improve accuracy and robustness
   - [x] predictor (or delayed) form to reduce computational load
 - [x] moving horizon estimator in two formulations:

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ for more detailed examples.
   - [x] measured outputs
 - [x] bumpless manual to automatic transfer for control with a proper initial estimate
 - [ ] estimators in two possible forms:
-  - [x] predictor (or delayed) form to reduce computational load
   - [x] filter (or current) form to improve accuracy and robustness
+  - [x] predictor (or delayed) form to reduce computational load
 - [x] moving horizon estimator in two formulations:
   - [x] linear plant models (quadratic optimization)
   - [x] nonlinear plant models (nonlinear optimization)

--- a/docs/src/manual/nonlinmpc.md
+++ b/docs/src/manual/nonlinmpc.md
@@ -378,7 +378,7 @@ nothing # hide
 
 The [`setmodel!`](@ref) method must be called after solving the optimization problem with
 [`moveinput!`](@ref) and before updating the state estimate with [`updatestate!`](@ref),
-that is, when both ``\mathbf{u}(k)`` and ``\mathbf{x̂}_{k-1}(k)`` are available as the new
+that is, when both ``\mathbf{u}(k)`` and ``\mathbf{x̂}_{k}(k)`` are available as the new
 operating point. The [`SimResult`](@ref) object is for plotting purposes only. The adaptive
 [`LinMPC`](@ref) performances are similar to the nonlinear MPC, both for the 180° setpoint:
 

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -94,10 +94,10 @@ LinMPC controller with a sample time Ts = 4.0 s, OSQP optimizer, SteadyKalmanFil
     Terminal constraints provide closed-loop stability guarantees on the nominal plant model.
     They can render an unfeasible problem however. In practice, a sufficiently large
     prediction horizon ``H_p`` without terminal constraints is typically enough for 
-    stability. If `mpc.estim.direct==true`, the state is estimated at ``i = k`` (the current
-    time step), otherwise at ``i = k - 1``. Note that terminal constraints are applied on the
-    augmented state vector ``\mathbf{x̂}`` (see [`SteadyKalmanFilter`](@ref) for details on
-    augmentation).
+    stability. If `mpc.estim.direct==true`, the estimator computes the states at ``i = k`` 
+    (the current time step), otherwise at ``i = k - 1``. Note that terminal constraints are
+    applied on the augmented state vector ``\mathbf{x̂}`` (see [`SteadyKalmanFilter`](@ref)
+    for details on augmentation).
 
     For variable constraints, the bounds can be modified after calling [`moveinput!`](@ref),
     that is, at runtime, but not the softness parameters ``\mathbf{c}``. It is not possible

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -146,13 +146,13 @@ end
 Return empty matrices, and `x̂op` & `f̂op` vectors, if `model` is not a [`LinModel`](@ref).
 """
 function augment_model(model::SimModel{NT}, As, args... ; verify_obsv=false) where NT<:Real
-    nu, nx, nd = model.nu, model.nx, model.nd
+    nu, nx, nd, ny = model.nu, model.nx, model.nd, model.ny
     nxs = size(As, 1)
     Â   = zeros(NT, 0, nx+nxs)
     B̂u  = zeros(NT, 0, nu)
-    Ĉ   = zeros(NT, 0, nx+nxs)
+    Ĉ   = zeros(NT, ny, 0)
     B̂d  = zeros(NT, 0, nd)
-    D̂d  = zeros(NT, 0, nd)
+    D̂d  = zeros(NT, ny, 0)
     x̂op, f̂op = [model.xop; zeros(nxs)], [model.fop; zeros(nxs)]
     return Â, B̂u, Ĉ, B̂d, D̂d, x̂op, f̂op
 end

--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -153,8 +153,8 @@ in which ``\mathbf{Ĉ^m, D̂_d^m}`` are the rows of `estim.Ĉ, estim.D̂d`  th
 measured outputs ``\mathbf{y^m}``.
 """
 function init_estimate!(estim::StateEstimator, ::LinModel, y0m, d0, u0)
-    Â, B̂u, Ĉ, B̂d, D̂d = estim.Â, estim.B̂u, estim.Ĉ, estim.B̂d, estim.D̂d
-    Ĉm, D̂dm = @views Ĉ[estim.i_ym, :], D̂d[estim.i_ym, :] # measured outputs ym only
+    Â, B̂u, B̂d = estim.Â, estim.B̂u, estim.B̂d
+    Ĉm, D̂dm = estim.Ĉm, estim.D̂dm
     # TODO: use estim.buffer.x̂ to reduce allocations
     estim.x̂0 .= [I - Â; Ĉm]\[B̂u*u0 + B̂d*d0 + estim.f̂op - estim.x̂op; y0m - D̂dm*d0]
     return nothing
@@ -390,6 +390,8 @@ function setmodel_estimator!(estim::StateEstimator, model, _ , _ , _ , Q̂, R̂)
     estim.Ĉ  .= Ĉ
     estim.B̂d .= B̂d
     estim.D̂d .= D̂d
+    estim.Ĉm  .= @views Ĉ[estim.i_ym, :]
+    estim.D̂dm .= @views D̂d[estim.i_ym, :]
     # --- update state estimate and its operating points ---
     estim.x̂0 .+= estim.x̂op # convert x̂0 to x̂ with the old operating point
     estim.x̂op .= x̂op

--- a/src/estimator/internal_model.jl
+++ b/src/estimator/internal_model.jl
@@ -228,8 +228,8 @@ function setmodel_estimator!(estim::InternalModel, model, _ , _ , _ , _ , _ )
     estim.Ĉ  .= Ĉ
     estim.B̂d .= B̂d
     estim.D̂d .= D̂d
-    estim.Ĉm .= @views Ĉ[estim.i_ym,:]
-    estim.D̂m .= @views D̂d[estim.i_ym,:]
+    estim.Ĉm  .= @views Ĉ[estim.i_ym,:]
+    estim.D̂dm .= @views D̂d[estim.i_ym,:]
     # --- update state estimate and its operating points ---
     estim.x̂0 .+= estim.x̂op # convert x̂0 to x̂ with the old operating point
     estim.x̂op .= x̂op

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -865,7 +865,7 @@ struct ExtendedKalmanFilter{NT<:Real, SM<:SimModel} <: StateEstimator{NT}
         R̂ = Hermitian(R̂, :L)
         P̂ = copy(P̂_0)
         K̂ = zeros(NT, nx̂, nym)
-        F̂_û, F̂ = zeros(NT, nx̂, nx̂+nu), zeros(NT, nx̂, nx̂)
+        F̂_û, F̂ = zeros(NT, nx̂+nu, nx̂), zeros(NT, nx̂, nx̂)
         Ĥ,  Ĥm = zeros(NT, ny, nx̂),    zeros(NT, nym, nx̂)
         corrected = [false]
         buffer = StateEstimatorBuffer{NT}(nu, nx̂, nym, ny, nd)

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -689,8 +689,8 @@ function correct_estimate!(estim::UnscentedKalmanFilter, y0m, d0)
     γ_sqrtP̂ = lmul!(γ, sqrtP̂)
     X̂0, Ŷ0m = estim.X̂0, estim.Ŷ0m
     X̂0 .= x̂0
-    X̂0[:, 2:nx̂+1]   .+= γ_sqrtP̂
-    X̂0[:, nx̂+2:end] .-= γ_sqrtP̂
+    X̂0[:, 2:nx̂+1]   .= @views X̂0[:, 2:nx̂+1]   .+ γ_sqrtP̂
+    X̂0[:, nx̂+2:end] .= @views X̂0[:, nx̂+2:end] .- γ_sqrtP̂
     ŷ0 = estim.buffer.ŷ
     for j in axes(Ŷ0m, 2)
         @views ĥ!(ŷ0, estim, estim.model, X̂0[:, j], d0)
@@ -784,8 +784,8 @@ function update_estimate!(estim::UnscentedKalmanFilter, y0m, d0, u0)
     sqrtP̂corr   = P̂corr_chol.L
     γ_sqrtP̂corr = lmul!(γ, sqrtP̂corr)
     X̂0corr .= x̂0corr
-    X̂0corr[:, 2:nx̂+1]   .+= γ_sqrtP̂corr
-    X̂0corr[:, nx̂+2:end] .-= γ_sqrtP̂corr
+    X̂0corr[:, 2:nx̂+1]   .= @views X̂0corr[:, 2:nx̂+1]   .+ γ_sqrtP̂corr
+    X̂0corr[:, nx̂+2:end] .= @views X̂0corr[:, nx̂+2:end] .- γ_sqrtP̂corr
     X̂0next = X̂0corr
     for j in axes(X̂0next, 2)
         @views x̂0corr .= X̂0corr[:, j]

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -682,6 +682,7 @@ function correct_estimate!(estim::UnscentedKalmanFilter, y0m, d0)
     X̂0, Ŷ0m = estim.X̂0, estim.Ŷ0m
     sqrtP̂ = estim.sqrtP̂
     ŷ0 = estim.buffer.ŷ
+    # in-place operations to reduce allocations:
     P̂_chol  = sqrtP̂.data
     P̂_chol .= P̂
     cholesky!(Hermitian(P̂_chol, :L)) # also modifies sqrtP̂
@@ -700,7 +701,7 @@ function correct_estimate!(estim::UnscentedKalmanFilter, y0m, d0)
     Ȳm .= Ŷ0m .- ŷ0m
     # TODO: use estim.buffer.R̂ here to reduce allocations
     M̂.data .= Ȳm * Ŝ * Ȳm' .+ R̂
-    mul!(K̂, X̄, lmul!(Ŝ, Ȳm'))
+    mul!(K̂, X̄, lmul!(Ŝ, Ȳm')) # also modifiers Ȳm' (not used after so it's okay)
     rdiv!(K̂, cholesky(M̂))
     v̂ = ŷ0m
     v̂ .= y0m .- ŷ0m
@@ -764,6 +765,7 @@ function update_estimate!(estim::UnscentedKalmanFilter, y0m, d0, u0)
     γ, m̂, Ŝ = estim.γ, estim.m̂, estim.Ŝ
     x̂0next, û0 = estim.buffer.x̂, estim.buffer.û
     P̂cor_chol  = sqrtP̂corr.data
+    # in-place operations to reduce allocations:
     P̂cor_chol .= P̂corr
     cholesky!(Hermitian(P̂cor_chol, :L)) # also modifies sqrtP̂cor
     γ_sqrtP̂corr = lmul!(γ, sqrtP̂corr)

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -427,8 +427,8 @@ provided below, see [^2] for details.
 # Correction Step
 ```math
 \begin{aligned}
-    \mathbf{Ŝ}(k)     &= \mathbf{Ĉ^m P̂}_{k-1}(k)\mathbf{Ĉ^m}' + \mathbf{R̂}                        \\
-    \mathbf{K̂}(k)     &= \mathbf{P̂}_{k-1}(k)\mathbf{Ĉ^m}'\mathbf{Ŝ^{-1}}(k)                       \\
+    \mathbf{M̂}(k)     &= \mathbf{Ĉ^m P̂}_{k-1}(k)\mathbf{Ĉ^m}' + \mathbf{R̂}                        \\
+    \mathbf{K̂}(k)     &= \mathbf{P̂}_{k-1}(k)\mathbf{Ĉ^m}'\mathbf{M̂^{-1}}(k)                       \\
     \mathbf{ŷ^m}(k)   &= \mathbf{Ĉ^m x̂}_{k-1}(k) + \mathbf{D̂_d^m d}(k)                            \\
     \mathbf{x̂}_{k}(k) &= \mathbf{x̂}_{k-1}(k) + \mathbf{K̂}(k)[\mathbf{y^m}(k) - \mathbf{ŷ^m}(k)]   \\
     \mathbf{P̂}_{k}(k) &= [\mathbf{I - K̂}(k)\mathbf{Ĉ^m}]\mathbf{P̂}_{k-1}(k)
@@ -1045,11 +1045,11 @@ function correct_estimate_kf!(estim::Union{KalmanFilter, ExtendedKalmanFilter}, 
     # in-place operations to reduce allocations:
     P̂_Ĉmᵀ = K̂
     mul!(P̂_Ĉmᵀ, P̂.data, Ĉm') # the ".data" weirdly removes a type instability in mul!
-    Ŝ = estim.buffer.R̂
-    mul!(Ŝ, Ĉm, P̂_Ĉmᵀ)
-    Ŝ .+= R̂
+    M̂ = estim.buffer.R̂
+    mul!(M̂, Ĉm, P̂_Ĉmᵀ)
+    M̂ .+= R̂
     K̂ = P̂_Ĉmᵀ
-    M̂_chol = cholesky!(Hermitian(Ŝ)) # also modifies Ŝ
+    M̂_chol = cholesky!(Hermitian(M̂)) # also modifies M̂
     rdiv!(K̂, M̂_chol)
     ŷ0 = estim.buffer.ŷ
     ĥ!(ŷ0, estim, estim.model, x̂0, d0)

--- a/src/estimator/luenberger.jl
+++ b/src/estimator/luenberger.jl
@@ -19,6 +19,8 @@ struct Luenberger{NT<:Real, SM<:LinModel} <: StateEstimator{NT}
     Ĉ   ::Matrix{NT}
     B̂d  ::Matrix{NT}
     D̂d  ::Matrix{NT}
+    Ĉm  ::Matrix{NT}
+    D̂dm ::Matrix{NT}
     K̂::Matrix{NT}
     direct::Bool
     corrected::Vector{Bool}
@@ -33,6 +35,7 @@ struct Luenberger{NT<:Real, SM<:LinModel} <: StateEstimator{NT}
         nxs = size(As, 1)
         nx̂  = model.nx + nxs
         Â, B̂u, Ĉ, B̂d, D̂d, x̂op, f̂op = augment_model(model, As, Cs_u, Cs_y)
+        Ĉm, D̂dm = Ĉ[i_ym, :], D̂d[i_ym, :]
         K̂ = try
             ControlSystemsBase.place(Â, Ĉ, poles, :o; direct)[:, i_ym]
         catch
@@ -47,7 +50,7 @@ struct Luenberger{NT<:Real, SM<:LinModel} <: StateEstimator{NT}
             lastu0, x̂op, f̂op, x̂0,
             i_ym, nx̂, nym, nyu, nxs, 
             As, Cs_u, Cs_y, nint_u, nint_ym,
-            Â, B̂u, Ĉ, B̂d, D̂d,
+            Â, B̂u, Ĉ, B̂d, D̂d, Ĉm, D̂dm,
             K̂,
             direct, corrected,
             buffer

--- a/src/estimator/luenberger.jl
+++ b/src/estimator/luenberger.jl
@@ -111,7 +111,7 @@ end
 
 
 """
-    prepare_estimate_obsv!(estim::Luenberger, y0m, d0, _ )
+    correct_estimate!(estim::Luenberger, y0m, d0, _ )
 
 Identical to [`correct_estimate!(::SteadyKalmanFilter)`](@ref) but using [`Luenberger`](@ref).
 """

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -496,6 +496,8 @@ function setmodel_estimator!(
     estim.Ĉ  .= Ĉ
     estim.B̂d .= B̂d
     estim.D̂d .= D̂d
+    estim.Ĉm  .= @views Ĉ[estim.i_ym, :]
+    estim.D̂dm .= @views D̂d[estim.i_ym, :]
     # --- update state estimate and its operating points ---
     x̂op_old = copy(estim.x̂op)
     estim.x̂0 .+= estim.x̂op # convert x̂0 to x̂ with the old operating point
@@ -504,7 +506,9 @@ function setmodel_estimator!(
     estim.x̂0 .-= estim.x̂op # convert x̂ to x̂0 with the new operating point
     # --- predictions matrices ---
     E, G, J, B, _ , Ex̂, Gx̂, Jx̂, Bx̂ = init_predmat_mhe(
-        model, He, estim.i_ym, Â, B̂u, Ĉ, B̂d, D̂d, x̂op, f̂op
+        model, He, estim.i_ym, 
+        estim.Â, estim.B̂u, estim.Ĉm, estim.B̂d, estim.D̂dm, 
+        estim.x̂op, estim.f̂op
     )
     A_X̂min, A_X̂max, Ẽx̂ = relaxX̂(model, nϵ, con.C_x̂min, con.C_x̂max, Ex̂)   
     A_V̂min, A_V̂max, Ẽ  = relaxV̂(model, nϵ, con.C_v̂min, con.C_v̂max, E) 

--- a/src/state_estim.jl
+++ b/src/state_estim.jl
@@ -25,6 +25,7 @@ struct StateEstimatorBuffer{NT<:Real}
     P̂ ::Matrix{NT}
     Q̂ ::Matrix{NT}
     R̂ ::Matrix{NT}
+    K̂ ::Matrix{NT}
     ym::Vector{NT}
     ŷ ::Vector{NT}
     d ::Vector{NT}
@@ -47,11 +48,12 @@ function StateEstimatorBuffer{NT}(
     P̂  = Matrix{NT}(undef, nx̂, nx̂)
     Q̂  = Matrix{NT}(undef, nx̂, nx̂)
     R̂  = Matrix{NT}(undef, nym, nym)
+    K̂  = Matrix{NT}(undef, nx̂, nym)
     ym = Vector{NT}(undef, nym)
     ŷ  = Vector{NT}(undef, ny)
     d  = Vector{NT}(undef, nd)
     empty = Vector{NT}(undef, 0)
-    return StateEstimatorBuffer{NT}(u, û, x̂, P̂, Q̂, R̂, ym, ŷ, d, empty)
+    return StateEstimatorBuffer{NT}(u, û, x̂, P̂, Q̂, R̂, K̂, ym, ŷ, d, empty)
 end
 
 const IntVectorOrInt = Union{Int, Vector{Int}}


### PR DESCRIPTION
`SteadyKalmanFilter`, `Luenberger`, `KalmanFilter` and `UnscentedKalmanFilter` are all 0 allocation for `preparestate!` and `updatestate!` functions