### PR TITLE
Fix type instability in `LinMPC` and `NonLinMPC` (introduced in 1.1.0) 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
 authors = ["Francis Gagnon"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -434,9 +434,7 @@ function validate_args(mpc::PredictiveController, ry, d, D̂, R̂y, R̂u)
     size(d)  ≠ (nd,)    && throw(DimensionMismatch("d size $(size(d)) ≠ measured dist. size ($nd,)"))
     size(D̂)  ≠ (nd*Hp,) && throw(DimensionMismatch("D̂ size $(size(D̂)) ≠ measured dist. size × Hp ($(nd*Hp),)"))
     size(R̂y) ≠ (ny*Hp,) && throw(DimensionMismatch("R̂y size $(size(R̂y)) ≠ output size × Hp ($(ny*Hp),)"))
-    if ~mpc.noR̂u
-        size(R̂u) ≠ (nu*Hp,) && throw(DimensionMismatch("R̂u size $(size(R̂u)) ≠ manip. input size × Hp ($(nu*Hp),)"))
-    end
+    size(R̂u) ≠ (nu*Hp,) && throw(DimensionMismatch("R̂u size $(size(R̂u)) ≠ manip. input size × Hp ($(nu*Hp),)"))
 end
 
 

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -27,7 +27,7 @@ struct ControllerWeights{NT<:Real}
 end
 
 "Include all the data for the constraints of [`PredictiveController`](@ref)"
-struct ControllerConstraint{NT<:Real, GCfunc<:Function}
+struct ControllerConstraint{NT<:Real, GCfunc<:Union{Nothing, Function}}
     ẽx̂      ::Matrix{NT}
     fx̂      ::Vector{NT}
     gx̂      ::Matrix{NT}
@@ -668,7 +668,7 @@ end
 """
     init_defaultcon_mpc(
         estim, C, S, E, ex̂, fx̂, gx̂, jx̂, kx̂, vx̂, 
-        gc!=(_,_,_,_,_,_)->nothing, nc=0
+        gc!=nothing, nc=0
     ) -> con, S̃, Ẽ
 
 Init `ControllerConstraint` struct with default parameters based on estimator `estim`.
@@ -676,10 +676,9 @@ Init `ControllerConstraint` struct with default parameters based on estimator `e
 Also return `S̃` and `Ẽ` matrices for the the augmented decision vector `ΔŨ`.
 """
 function init_defaultcon_mpc(
-    estim::StateEstimator{NT}, 
-    Hp, Hc, C, S, E, ex̂, fx̂, gx̂, jx̂, kx̂, vx̂, bx̂, 
-    gc!::GCfunc=(_,_,_,_,_,_)->nothing, nc=0
-) where {NT<:Real, GCfunc<:Function}
+    estim::StateEstimator{NT}, Hp, Hc, C, S, E, ex̂, fx̂, gx̂, jx̂, kx̂, vx̂, bx̂, 
+    gc!::GCfunc=nothing, nc=0
+) where {NT<:Real, GCfunc<:Union{Nothing, Function}}
     model = estim.model
     nu, ny, nx̂ = model.nu, model.ny, estim.nx̂
     nϵ = isinf(C) ? 0 : 1

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -371,11 +371,10 @@ The function mutates `Ue`, `Ŷe` and `Ū` in arguments, without assuming any i
 function extended_predictions!(Ue, Ŷe, Ū, mpc, model, Ŷ0, ΔŨ)
     ny, nu = model.ny, model.nu
     # --- extended manipulated inputs Ue = [U; u(k+Hp-1)] ---
-    U0 = Ū
-    U0 .= mul!(U0, mpc.S̃, ΔŨ) .+ mpc.T_lastu0
-    Ue[1:end-nu] .= U0 .+ mpc.Uop
+    U  = Ū
+    U .= mul!(U, mpc.S̃, ΔŨ) .+ mpc.T_lastu0 .+ mpc.Uop
     # u(k + Hp) = u(k + Hp - 1) since Δu(k+Hp) = 0 (because Hc ≤ Hp):
-    Ue[end-nu+1:end] .= @views Ue[end-2nu+1:end-nu]
+    Ue[end-nu+1:end] .= @views U[end-nu+1:end]
     # --- extended output predictions Ŷe = [ŷ(k); Ŷ] ---
     Ŷe[1:ny]     .= mpc.ŷ
     Ŷe[ny+1:end] .= Ŷ0 .+ mpc.Yop

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -191,8 +191,7 @@ They are computed with these equations using in-place operations:
 function initpred!(mpc::PredictiveController, model::LinModel, d, D̂, R̂y, R̂u)
     mul!(mpc.T_lastu0, mpc.T, mpc.estim.lastu0)
     ŷ, F, q̃, r = mpc.ŷ, mpc.F, mpc.q̃, mpc.r
-    Cy, Cu = mpc.buffer.Cy, mpc.buffer.Cu
-    M_Hp_Ẽ, L_Hp_S̃ = mpc.buffer.Ẽ, mpc.buffer.S̃
+    Cy, Cu, M_Hp_Ẽ, L_Hp_S̃ = mpc.buffer.Ŷ, mpc.buffer.U, mpc.buffer.Ẽ, mpc.buffer.S̃
     ŷ .= evaloutput(mpc.estim, d)
     predictstoch!(mpc, mpc.estim)           # init F with Ŷs for InternalModel
     F .+= mpc.B                             # F = F + B

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -373,12 +373,13 @@ function extended_predictions!(Ue, Ŷe, Ū, mpc, model, Ŷ0, ΔŨ)
     # --- extended manipulated inputs Ue = [U; u(k+Hp-1)] ---
     U  = Ū
     U .= mul!(U, mpc.S̃, ΔŨ) .+ mpc.T_lastu0 .+ mpc.Uop
+    Ue[1:end-nu] .= U
     # u(k + Hp) = u(k + Hp - 1) since Δu(k+Hp) = 0 (because Hc ≤ Hp):
     Ue[end-nu+1:end] .= @views U[end-nu+1:end]
     # --- extended output predictions Ŷe = [ŷ(k); Ŷ] ---
     Ŷe[1:ny]     .= mpc.ŷ
     Ŷe[ny+1:end] .= Ŷ0 .+ mpc.Yop
-    return Ue, Ŷe
+    return Ue, Ŷe 
 end
 
 """

--- a/src/controller/explicitmpc.jl
+++ b/src/controller/explicitmpc.jl
@@ -60,7 +60,7 @@ struct ExplicitMPC{NT<:Real, SE<:StateEstimator} <: PredictiveController{NT}
         Uop, Yop, Dop = repeat(model.uop, Hp), repeat(model.yop, Hp), repeat(model.dop, Hp)
         nΔŨ = size(Ẽ, 2)
         ΔŨ = zeros(NT, nΔŨ)
-        buffer = PredictiveControllerBuffer{NT}(nu, ny, nd, Hp)
+        buffer = PredictiveControllerBuffer{NT}(nu, ny, nd, Hp, Hc, nϵ)
         mpc = new{NT, SE}(
             estim,
             ΔŨ, ŷ,

--- a/src/controller/explicitmpc.jl
+++ b/src/controller/explicitmpc.jl
@@ -8,7 +8,6 @@ struct ExplicitMPC{NT<:Real, SE<:StateEstimator} <: PredictiveController{NT}
     weights::ControllerWeights{NT}
     R̂u::Vector{NT}
     R̂y::Vector{NT}
-    noR̂u::Bool
     S̃::Matrix{NT} 
     T::Matrix{NT}
     T_lastu0::Vector{NT}
@@ -46,7 +45,6 @@ struct ExplicitMPC{NT<:Real, SE<:StateEstimator} <: PredictiveController{NT}
         L_Hp = Hermitian(convert(Matrix{NT}, L_Hp), :L)
         # dummy vals (updated just before optimization):
         R̂y, R̂u, T_lastu0 = zeros(NT, ny*Hp), zeros(NT, nu*Hp), zeros(NT, nu*Hp)
-        noR̂u = iszero(L_Hp)
         S, T = init_ΔUtoU(model, Hp, Hc)
         E, G, J, K, V, B = init_predmat(estim, model, Hp, Hc)
         # dummy val (updated just before optimization):
@@ -68,7 +66,7 @@ struct ExplicitMPC{NT<:Real, SE<:StateEstimator} <: PredictiveController{NT}
             ΔŨ, ŷ,
             Hp, Hc, nϵ,
             weights,
-            R̂u, R̂y, noR̂u,
+            R̂u, R̂y,
             S̃, T, T_lastu0,
             Ẽ, F, G, J, K, V, B,
             H̃, q̃, r,

--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -9,7 +9,7 @@ struct LinMPC{
     # note: `NT` and the number type `JNT` in `JuMP.GenericModel{JNT}` can be
     # different since solvers that support non-Float64 are scarce.
     optim::JM
-    con::ControllerConstraint{NT}
+    con::ControllerConstraint{NT, Nothing}
     ΔŨ::Vector{NT}
     ŷ ::Vector{NT}
     Hp::Int

--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -65,7 +65,7 @@ struct LinMPC{
         Uop, Yop, Dop = repeat(model.uop, Hp), repeat(model.yop, Hp), repeat(model.dop, Hp)
         nΔŨ = size(Ẽ, 2)
         ΔŨ = zeros(NT, nΔŨ)
-        buffer = PredictiveControllerBuffer{NT}(nu, ny, nd, Hp)
+        buffer = PredictiveControllerBuffer{NT}(nu, ny, nd, Hp, Hc, nϵ)
         mpc = new{NT, SE, JM}(
             estim, optim, con,
             ΔŨ, ŷ,

--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -18,7 +18,6 @@ struct LinMPC{
     weights::ControllerWeights{NT}
     R̂u::Vector{NT}
     R̂y::Vector{NT}
-    noR̂u::Bool
     S̃::Matrix{NT} 
     T::Matrix{NT}
     T_lastu0::Vector{NT}
@@ -50,7 +49,6 @@ struct LinMPC{
         weights = ControllerWeights{NT}(model, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt)
         # dummy vals (updated just before optimization):
         R̂y, R̂u, T_lastu0 = zeros(NT, ny*Hp), zeros(NT, nu*Hp), zeros(NT, nu*Hp)
-        noR̂u = iszero(L_Hp)
         S, T = init_ΔUtoU(model, Hp, Hc)
         E, G, J, K, V, B, ex̂, gx̂, jx̂, kx̂, vx̂, bx̂ = init_predmat(estim, model, Hp, Hc)
         # dummy vals (updated just before optimization):
@@ -73,7 +71,7 @@ struct LinMPC{
             ΔŨ, ŷ,
             Hp, Hc, nϵ,
             weights,
-            R̂u, R̂y, noR̂u,
+            R̂u, R̂y,
             S̃, T, T_lastu0,
             Ẽ, F, G, J, K, V, B, 
             H̃, q̃, r,

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -2,16 +2,17 @@ const DEFAULT_NONLINMPC_OPTIMIZER = optimizer_with_attributes(Ipopt.Optimizer,"s
 
 struct NonLinMPC{
     NT<:Real, 
-    SE<:StateEstimator, 
+    SE<:StateEstimator,
     JM<:JuMP.GenericModel, 
     JEfunc<:Function,
+    GCfunc<:Function,
     P<:Any
 } <: PredictiveController{NT}
     estim::SE
     # note: `NT` and the number type `JNT` in `JuMP.GenericModel{JNT}` can be
     # different since solvers that support non-Float64 are scarce.
     optim::JM
-    con::ControllerConstraint{NT}
+    con::ControllerConstraint{NT, GCfunc}
     ΔŨ::Vector{NT}
     ŷ ::Vector{NT}
     Hp::Int
@@ -48,9 +49,17 @@ struct NonLinMPC{
     Yop::Vector{NT}
     Dop::Vector{NT}
     buffer::PredictiveControllerBuffer{NT}
-    function NonLinMPC{NT, SE, JM, JEfunc, P}(
-        estim::SE, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt, Ewt, JE::JEfunc, gc, nc, p::P, optim::JM
-    ) where {NT<:Real, SE<:StateEstimator, JM<:JuMP.GenericModel, JEfunc<:Function, P<:Any}
+    function NonLinMPC{NT, SE, JM, JEfunc, GCfunc, P}(
+        estim::SE, 
+        Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt, Ewt, JE::JEfunc, gc::GCfunc, nc, p::P, optim::JM
+    ) where {
+            NT<:Real, 
+            SE<:StateEstimator, 
+            JM<:JuMP.GenericModel, 
+            JEfunc<:Function, 
+            GCfunc<:Function, 
+            P<:Any
+        }
         model = estim.model
         nu, ny, nd, nx̂ = model.nu, model.ny, model.nd, estim.nx̂
         ŷ = copy(model.yop) # dummy vals (updated just before optimization)
@@ -82,7 +91,7 @@ struct NonLinMPC{
         nΔŨ = size(Ẽ, 2)
         ΔŨ = zeros(NT, nΔŨ)
         buffer = PredictiveControllerBuffer{NT}(nu, ny, nd, Hp)
-        mpc = new{NT, SE, JM, JEfunc, P}(
+        mpc = new{NT, SE, JM, JEfunc, GCfunc, P}(
             estim, optim, con,
             ΔŨ, ŷ,
             Hp, Hc, nϵ,
@@ -318,9 +327,9 @@ function NonLinMPC(
     L_Hp = diagm(repeat(Lwt, Hp)),
     Cwt  = DEFAULT_CWT,
     Ewt  = DEFAULT_EWT,
-    JE ::JEfunc = (_,_,_,_) -> 0.0,
+    JE ::JEfunc   = (_,_,_,_) -> 0.0,
     gc!::Function = (_,_,_,_,_,_) -> nothing,
-    gc ::Function = gc!,
+    gc ::GCfunc   = gc!,
     nc = 0,
     p::P = estim.model.p,
     optim::JM = JuMP.Model(DEFAULT_NONLINMPC_OPTIMIZER, add_bridges=false),
@@ -329,6 +338,7 @@ function NonLinMPC(
     SE<:StateEstimator{NT}, 
     JM<:JuMP.GenericModel, 
     JEfunc<:Function,
+    GCfunc<:Function,
     P<:Any
 }
     nk = estimate_delays(estim.model)
@@ -336,7 +346,7 @@ function NonLinMPC(
         @warn("prediction horizon Hp ($Hp) ≤ estimated number of delays in model "*
               "($nk), the closed-loop system may be unstable or zero-gain (unresponsive)")
     end
-    return NonLinMPC{NT, SE, JM, JEfunc, P}(
+    return NonLinMPC{NT, SE, JM, JEfunc, GCfunc, P}(
         estim, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt, Ewt, JE, gc, nc, p, optim
     )
 end
@@ -520,7 +530,7 @@ function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT
         gc         = get_tmp(gc_cache, ΔŨ1)
         Ŷ0, x̂0end  = predict!(Ȳ, x̂0, x̂0next, u0, û0, mpc, model, ΔŨ)
         Ue, Ŷe     = extended_predictions!(Ue, Ŷe, Ū, mpc, model, Ŷ0, ΔŨ)
-        ϵ = (nϵ ≠ 0) ? ΔŨ[end] : zero(T) # ϵ = 0 if nϵ == 0 (meaning no relaxation)
+        ϵ = (nϵ ≠ 0) ? ΔŨ[end] : 0 # ϵ = 0 if nϵ == 0 (meaning no relaxation)
         mpc.con.gc!(gc, Ue, Ŷe, mpc.D̂e, mpc.p, ϵ)
         g = con_nonlinprog!(g, mpc, model, x̂0end, Ŷ0, gc, ϵ)
         return obj_nonlinprog!(Ȳ, Ū, mpc, model, Ue, Ŷe, ΔŨ)::T
@@ -539,7 +549,7 @@ function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT
             gc         = get_tmp(gc_cache, ΔŨ1)
             Ŷ0, x̂0end  = predict!(Ȳ, x̂0, x̂0next, u0, û0, mpc, model, ΔŨ)
             Ue, Ŷe     = extended_predictions!(Ue, Ŷe, Ū, mpc, model, Ŷ0, ΔŨ)
-            ϵ = (nϵ ≠ 0) ? ΔŨ[end] : zero(T) # ϵ = 0 if nϵ == 0 (meaning no relaxation)
+            ϵ = (nϵ ≠ 0) ? ΔŨ[end] : 0 # ϵ = 0 if nϵ == 0 (meaning no relaxation)
             mpc.con.gc!(gc, Ue, Ŷe, mpc.D̂e, mpc.p, ϵ)
             g = con_nonlinprog!(g, mpc, model, x̂0end, Ŷ0, gc, ϵ)
         end

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -23,7 +23,6 @@ struct NonLinMPC{
     p::P
     R̂u::Vector{NT}
     R̂y::Vector{NT}
-    noR̂u::Bool
     S̃::Matrix{NT}
     T::Matrix{NT}
     T_lastu0::Vector{NT}
@@ -63,7 +62,6 @@ struct NonLinMPC{
         weights = ControllerWeights{NT}(model, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt, Ewt)
         # dummy vals (updated just before optimization):
         R̂y, R̂u, T_lastu0 = zeros(NT, ny*Hp), zeros(NT, nu*Hp), zeros(NT, nu*Hp)
-        noR̂u = iszero(L_Hp)
         S, T = init_ΔUtoU(model, Hp, Hc)
         E, G, J, K, V, B, ex̂, gx̂, jx̂, kx̂, vx̂, bx̂ = init_predmat(estim, model, Hp, Hc)
         # dummy vals (updated just before optimization):
@@ -88,7 +86,7 @@ struct NonLinMPC{
             Hp, Hc, nϵ,
             weights,
             JE, p,
-            R̂u, R̂y, noR̂u,
+            R̂u, R̂y,
             S̃, T, T_lastu0,
             Ẽ, F, G, J, K, V, B,
             H̃, q̃, r,

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -79,7 +79,7 @@ struct NonLinMPC{
         test_custom_functions(NT, model, JE, gc!, nc, Uop, Yop, Dop, p)
         nΔŨ = size(Ẽ, 2)
         ΔŨ = zeros(NT, nΔŨ)
-        buffer = PredictiveControllerBuffer{NT}(nu, ny, nd, Hp)
+        buffer = PredictiveControllerBuffer{NT}(nu, ny, nd, Hp, Hc, nϵ)
         mpc = new{NT, SE, JM, JEfunc, GCfunc, P}(
             estim, optim, con,
             ΔŨ, ŷ,

--- a/src/predictive_control.jl
+++ b/src/predictive_control.jl
@@ -25,6 +25,8 @@ struct PredictiveControllerBuffer{NT<:Real}
     D̂ ::Vector{NT}
     Cy::Vector{NT}
     Cu::Vector{NT}
+    Ẽ ::Matrix{NT}
+    S̃ ::Matrix{NT}
     empty::Vector{NT}
 end
 
@@ -35,14 +37,18 @@ Create a buffer for `PredictiveController` objects.
 
 The buffer is used to store intermediate results during computation without allocating.
 """
-function PredictiveControllerBuffer{NT}(nu::Int, ny::Int, nd::Int, Hp::Int) where NT <: Real
+function PredictiveControllerBuffer{NT}(
+    nu::Int, ny::Int, nd::Int, Hp::Int, Hc::Int, nϵ::Int
+) where NT <: Real
     u  = Vector{NT}(undef, nu)
     R̂y = Vector{NT}(undef, ny*Hp)
     D̂  = Vector{NT}(undef, nd*Hp)
     Cy = Vector{NT}(undef, ny*Hp)
     Cu = Vector{NT}(undef, nu*Hp)
+    Ẽ  = Matrix{NT}(undef, ny*Hp, nu*Hc + nϵ)
+    S̃  = Matrix{NT}(undef, nu*Hp, nu*Hc + nϵ)
     empty = Vector{NT}(undef, 0)
-    return PredictiveControllerBuffer{NT}(u, R̂y, D̂, Cy, Cu, empty)
+    return PredictiveControllerBuffer{NT}(u, R̂y, D̂, Cy, Cu, Ẽ, S̃, empty)
 end
 
 include("controller/construct.jl")

--- a/src/predictive_control.jl
+++ b/src/predictive_control.jl
@@ -23,6 +23,8 @@ struct PredictiveControllerBuffer{NT<:Real}
     u ::Vector{NT}
     R̂y::Vector{NT}
     D̂ ::Vector{NT}
+    Cy::Vector{NT}
+    Cu::Vector{NT}
     empty::Vector{NT}
 end
 
@@ -37,8 +39,10 @@ function PredictiveControllerBuffer{NT}(nu::Int, ny::Int, nd::Int, Hp::Int) wher
     u  = Vector{NT}(undef, nu)
     R̂y = Vector{NT}(undef, ny*Hp)
     D̂  = Vector{NT}(undef, nd*Hp)
+    Cy = Vector{NT}(undef, ny*Hp)
+    Cu = Vector{NT}(undef, nu*Hp)
     empty = Vector{NT}(undef, 0)
-    return PredictiveControllerBuffer{NT}(u, R̂y, D̂, empty)
+    return PredictiveControllerBuffer{NT}(u, R̂y, D̂, Cy, Cu, empty)
 end
 
 include("controller/construct.jl")

--- a/src/predictive_control.jl
+++ b/src/predictive_control.jl
@@ -23,8 +23,8 @@ struct PredictiveControllerBuffer{NT<:Real}
     u ::Vector{NT}
     R̂y::Vector{NT}
     D̂ ::Vector{NT}
-    Cy::Vector{NT}
-    Cu::Vector{NT}
+    Ŷ ::Vector{NT}
+    U ::Vector{NT}
     Ẽ ::Matrix{NT}
     S̃ ::Matrix{NT}
     empty::Vector{NT}
@@ -43,12 +43,12 @@ function PredictiveControllerBuffer{NT}(
     u  = Vector{NT}(undef, nu)
     R̂y = Vector{NT}(undef, ny*Hp)
     D̂  = Vector{NT}(undef, nd*Hp)
-    Cy = Vector{NT}(undef, ny*Hp)
-    Cu = Vector{NT}(undef, nu*Hp)
+    Ŷ  = Vector{NT}(undef, ny*Hp)
+    U  = Vector{NT}(undef, nu*Hp)
     Ẽ  = Matrix{NT}(undef, ny*Hp, nu*Hc + nϵ)
     S̃  = Matrix{NT}(undef, nu*Hp, nu*Hc + nϵ)
     empty = Vector{NT}(undef, 0)
-    return PredictiveControllerBuffer{NT}(u, R̂y, D̂, Cy, Cu, Ẽ, S̃, empty)
+    return PredictiveControllerBuffer{NT}(u, R̂y, D̂, Ŷ, U, Ẽ, S̃, empty)
 end
 
 include("controller/construct.jl")

--- a/test/test_predictive_control.jl
+++ b/test/test_predictive_control.jl
@@ -854,7 +854,7 @@ end
 end
 
 @testset "NonLinMPC set model" begin
-    estim = KalmanFilter(setop!(LinModel(tf(5, [2, 1]), 3), yop=[10], uop=[1]))
+    estim = KalmanFilter(setop!(LinModel(tf(5, [200, 1]), 300), yop=[10], uop=[1]))
     mpc = NonLinMPC(estim, Nwt=[0], Cwt=1e4, Hp=1000, Hc=1)
     mpc = setconstraint!(mpc, umin=[-24], umax=[26])
     mpc = setconstraint!(mpc, ymin=[-54], ymax=[56])
@@ -868,7 +868,7 @@ end
     preparestate!(mpc, [10])
     u = moveinput!(mpc, r)
     @test u ≈ [2] atol=1e-2
-    setmodel!(mpc, setop!(LinModel(tf(5, [2, 1]), 3), yop=[20], uop=[11]))
+    setmodel!(mpc, setop!(LinModel(tf(5, [200, 1]), 300), yop=[20], uop=[11]))
     @test mpc.Yop ≈ fill(20.0, 1000)
     @test mpc.Uop ≈ fill(11.0, 1000)
     @test mpc.con.U0min ≈ fill(-24.0 - 1  + 1  - 11,  1000)
@@ -878,7 +878,7 @@ end
     r = [40]
     u = moveinput!(mpc, r)
     @test u ≈ [15] atol=1e-2
-    setmodel!(mpc, setop!(LinModel(tf(10, [2, 1]), 3), yop=[20], uop=[11]))
+    setmodel!(mpc, setop!(LinModel(tf(10, [200, 1]), 300), yop=[20], uop=[11]))
     r = [40]
     u = moveinput!(mpc, r)
     @test u ≈ [13] atol=1e-2


### PR DESCRIPTION
`ControllerConstraint{NT}` is no longer concrete
`ControllerConstraint{NT, GCfunc}` is