### PR TITLE
Added: slightly speed up `NonLinMPC` and `MovingHorizonEstimator` 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.1.4"
 
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"
+DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -18,6 +19,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
 ControlSystemsBase = "1.9"
+DiffResults = "1.1.0"
 ForwardDiff = "0.10"
 Ipopt = "1"
 JuMP = "1.21"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
 authors = ["Francis Gagnon"]
-version = "1.1.4"
+version = "1.2.0"
 
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.1.4"
 
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"
-DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -19,7 +18,6 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
 ControlSystemsBase = "1.9"
-DiffResults = "1.1.0"
 ForwardDiff = "0.10"
 Ipopt = "1"
 JuMP = "1.21"

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -397,7 +397,7 @@ function extended_predictions!(Ŷe, Ue, Ū, mpc, model, Ŷ0, ΔŨ)
         Ŷe[ny+1:end] .= Ŷ0 .+ mpc.Yop
     end
     # --- extended manipulated inputs Ue = [U; u(k+Hp-1)] ---
-    if !(mpc.weights.iszero_L_Hp[] && mpc.nocustomfcts)
+    if !(mpc.weights.iszero_L_Hp[] && nocustomfcts)
         U  = Ū
         U .= mul!(U, mpc.S̃, ΔŨ) .+ mpc.T_lastu
         Ue[1:end-nu] .= U

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -390,9 +390,9 @@ special cases in which `Ŷe`, `Ue` and `Ū` are not mutated:
 """
 function extended_predictions!(Ŷe, Ue, Ū, mpc, model, Ŷ0, ΔŨ)
     ny, nu = model.ny, model.nu
-    nocustomfonctions = (mpc.weights.iszero_E && iszero_nc(mpc))
+    nocustomfcts = (mpc.weights.iszero_E && iszero_nc(mpc))
     # --- extended output predictions Ŷe = [ŷ(k); Ŷ] ---
-    if !(mpc.weights.iszero_M_Hp[] && mpc.nocustomfcts)
+    if !(mpc.weights.iszero_M_Hp[] && nocustomfcts)
         Ŷe[1:ny] .= mpc.ŷ
         Ŷe[ny+1:end] .= Ŷ0 .+ mpc.Yop
     end

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -403,8 +403,6 @@ function extended_predictions!(Ŷe, Ue, Ū, mpc, model, Ŷ0, ΔŨ)
         Ue[1:end-nu] .= U
         # u(k + Hp) = u(k + Hp - 1) since Δu(k+Hp) = 0 (because Hc ≤ Hp):
         Ue[end-nu+1:end] .= @views U[end-nu+1:end]
-    else
-        print("yo")
     end
     return Ŷe, Ue 
 end

--- a/src/controller/explicitmpc.jl
+++ b/src/controller/explicitmpc.jl
@@ -195,6 +195,8 @@ function predict!(Ŷ, x̂, _ , _ , _ , mpc::ExplicitMPC, ::LinModel, ΔŨ)
     return Ŷ, x̂
 end
 
+"`ExplicitMPC` does not support custom nonlinear constraint, return `true`."
+iszero_nc(mpc::ExplicitMPC) = true
 
 """
     addinfo!(info, mpc::ExplicitMPC) -> info

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -526,7 +526,7 @@ function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT
             u0, û0     = get_tmp(u0_cache, ΔŨ1), get_tmp(û0_cache, ΔŨ1)
             gc, g      = get_tmp(gc_cache, ΔŨ1), get_tmp(g_cache, ΔŨ1)
             Ŷ0, x̂0end  = predict!(Ȳ, x̂0, x̂0next, u0, û0, mpc, model, ΔŨ)
-            Ue, Ŷe     = extended_predictions!(Ue, Ŷe, Ū, mpc, model, Ŷ0, ΔŨ)
+            Ŷe, Ue     = extended_predictions!(Ŷe, Ue, Ū, mpc, model, Ŷ0, ΔŨ)
             ϵ = (nϵ ≠ 0) ? ΔŨ[end] : zero(T) # ϵ = 0 if nϵ == 0 (meaning no relaxation)
             gc = con_custom!(gc, mpc, Ue, Ŷe, ϵ)
             g  = con_nonlinprog!(g, mpc, model, x̂0end, Ŷ0, gc, ϵ)

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -490,9 +490,10 @@ function init_optimization!(mpc::NonLinMPC, model::SimModel, optim)
 end
 
 """
-    get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel) -> Jfunc, gfunc
+    get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel) -> Jfunc, gfuncs
 
-Get the objective `Jfunc` and constraints `gfunc` functions for [`NonLinMPC`](@ref).
+Get the objective `Jfunc` function and constraint `gfuncs` function vector for 
+[`NonLinMPC`](@ref).
 
 Inspired from: [User-defined operators with vector outputs](https://jump.dev/JuMP.jl/stable/tutorials/nonlinear/tips_and_tricks/#User-defined-operators-with-vector-outputs)
 """

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -554,7 +554,6 @@ function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT
             return gfunc_i(i, ΔŨtup)
         end
     end
-    #gfunc = [(ΔŨ::Vararg{T, N}) -> gfunc_i(i, ΔŨ) where {N, T<:Real} for i in 1:ng]  
     return Jfunc, gfuncs
 end
 

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -1289,9 +1289,10 @@ end
 
 
 """
-    get_optim_functions(estim::MovingHorizonEstimator, ::JuMP.GenericModel) -> Jfunc, gfunc
+    get_optim_functions(estim::MovingHorizonEstimator, ::JuMP.GenericModel) -> Jfunc, gfuncs
 
-Get the objective `Jfunc` and constraints `gfunc` functions for [`MovingHorizonEstimator`](@ref).
+Get the objective `Jfunc` function and constraint `gfuncs` function vector for 
+[`MovingHorizonEstimator`](@ref).
 
 Inspired from: [User-defined operators with vector outputs](https://jump.dev/JuMP.jl/stable/tutorials/nonlinear/tips_and_tricks/#User-defined-operators-with-vector-outputs)
 """

--- a/src/model/solver.jl
+++ b/src/model/solver.jl
@@ -39,54 +39,70 @@ RungeKutta(order::Int=4; supersample::Int=1) = RungeKutta(order, supersample)
 
 "Get the `f!` and `h!` functions for the explicit Runge-Kutta solvers."
 function get_solver_functions(NT::DataType, solver::RungeKutta, fc!, hc!, Ts, _ , nx, _ , _ )
-    order = solver.order
-    Ts_inner = Ts/solver.supersample
     Nc = nx + 2
+    f! = if solver.order==4
+        get_rk4_function(NT, solver, fc!, Ts, nx, Nc)
+    elseif solver.order==1
+        get_euler_function(NT, solver, fc!, Ts, nx, Nc)
+    else
+        throw(ArgumentError("only 1st and 4th order Runge-Kutta is supported."))
+    end
+    h! = hc!
+    return f!, h!
+end
+
+"Get the f! function for the 4th order explicit Runge-Kutta solver."
+function get_rk4_function(NT, solver, fc!, Ts, nx, Nc)
+    Ts_inner = Ts/solver.supersample
     xcur_cache::DiffCache{Vector{NT}, Vector{NT}} = DiffCache(zeros(NT, nx), Nc)
     k1_cache::DiffCache{Vector{NT}, Vector{NT}}   = DiffCache(zeros(NT, nx), Nc)
     k2_cache::DiffCache{Vector{NT}, Vector{NT}}   = DiffCache(zeros(NT, nx), Nc)
     k3_cache::DiffCache{Vector{NT}, Vector{NT}}   = DiffCache(zeros(NT, nx), Nc)
     k4_cache::DiffCache{Vector{NT}, Vector{NT}}   = DiffCache(zeros(NT, nx), Nc)
-    if order==1
-        f! = function euler_solver!(xnext, x, u, d, p)
-            CT = promote_type(eltype(x), eltype(u), eltype(d))
-            xcur = get_tmp(xcur_cache, CT)
-            k1   = get_tmp(k1_cache, CT)
-            xterm = xnext
-            @. xcur = x
-            for i=1:solver.supersample
-                fc!(k1, xcur, u, d, p)
-                @. xcur = xcur + k1 * Ts_inner
-            end
-            @. xnext = xcur
-            return nothing
+    f! = function rk4_solver!(xnext, x, u, d, p)
+        CT = promote_type(eltype(x), eltype(u), eltype(d))
+        xcur = get_tmp(xcur_cache, CT)
+        k1   = get_tmp(k1_cache, CT)
+        k2   = get_tmp(k2_cache, CT)
+        k3   = get_tmp(k3_cache, CT)
+        k4   = get_tmp(k4_cache, CT)
+        xterm = xnext
+        @. xcur = x
+        for i=1:solver.supersample
+            fc!(k1, xcur, u, d, p)
+            @. xterm = xcur + k1 * Ts_inner/2
+            fc!(k2, xterm, u, d, p)
+            @. xterm = xcur + k2 * Ts_inner/2
+            fc!(k3, xterm, u, d, p)
+            @. xterm = xcur + k3 * Ts_inner
+            fc!(k4, xterm, u, d, p)
+            @. xcur = xcur + (k1 + 2k2 + 2k3 + k4)*Ts_inner/6
         end
-    elseif order==4
-        f! = function rk4_solver!(xnext, x, u, d, p)
-            CT = promote_type(eltype(x), eltype(u), eltype(d))
-            xcur = get_tmp(xcur_cache, CT)
-            k1   = get_tmp(k1_cache, CT)
-            k2   = get_tmp(k2_cache, CT)
-            k3   = get_tmp(k3_cache, CT)
-            k4   = get_tmp(k4_cache, CT)
-            xterm = xnext
-            @. xcur = x
-            for i=1:solver.supersample
-                fc!(k1, xcur, u, d, p)
-                @. xterm = xcur + k1 * Ts_inner/2
-                fc!(k2, xterm, u, d, p)
-                @. xterm = xcur + k2 * Ts_inner/2
-                fc!(k3, xterm, u, d, p)
-                @. xterm = xcur + k3 * Ts_inner
-                fc!(k4, xterm, u, d, p)
-                @. xcur = xcur + (k1 + 2k2 + 2k3 + k4)*Ts_inner/6
-            end
-            @. xnext = xcur
-            return nothing
-        end
+        @. xnext = xcur
+        return nothing
     end
-    h! = hc!
-    return f!, h!
+    return f!
+end
+
+"Get the f! function for the explicit Euler solver."
+function get_euler_function(NT, solver, fc!, Ts, nx, Nc)
+    Ts_inner = Ts/solver.supersample
+    xcur_cache::DiffCache{Vector{NT}, Vector{NT}} = DiffCache(zeros(NT, nx), Nc)
+    k_cache::DiffCache{Vector{NT}, Vector{NT}}    = DiffCache(zeros(NT, nx), Nc)
+    f! = function euler_solver!(xnext, x, u, d, p)
+        CT = promote_type(eltype(x), eltype(u), eltype(d))
+        xcur = get_tmp(xcur_cache, CT)
+        k    = get_tmp(k_cache, CT)
+        xterm = xnext
+        @. xcur = x
+        for i=1:solver.supersample
+            fc!(k, xcur, u, d, p)
+            @. xcur = xcur + k * Ts_inner
+        end
+        @. xnext = xcur
+        return nothing
+    end
+    return f!
 end
 
 """


### PR DESCRIPTION
- forcing specialization in the NLP functions by using `Vararg{T, N}` instead of splatting (see this [tip](https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing))
- skipping computations in `extended_predictions` when possible
- also improved code reuse in the NLP functions to improve code maintainability  