### PR TITLE
changed: `@error` instead of `@warn` in MHE arrival covariance fallback + update CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,9 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    permissions: # needed for julia-actions/cache delete old caches that it has created
+      actions: write
+      contents: read
     continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
@@ -28,10 +31,10 @@ jobs:
         arch:
           - x64
     steps:
-      - name: Set JULIA_DEBUG environment variable
+      - name: Set JULIA_DEBUG environment variable if applicable
         if: ${{ runner.debug == '1' }}
         run: echo "JULIA_DEBUG=ModelPredictiveControl" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,9 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
-          - '1.10'
-          - 'nightly'
+          - 'lts' # long-term support release
+          - '1'   # latest stable 1.x release
+          - 'pre' # latest stable prerelease
+          # - 'nightly' # commented since noisy + 'pre' allows testing upcoming versions
         os:
           - ubuntu-latest
         arch:
@@ -31,11 +32,11 @@ jobs:
         if: ${{ runner.debug == '1' }}
         run: echo "JULIA_DEBUG=ModelPredictiveControl" >> $GITHUB_ENV
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -77,7 +77,7 @@ following fields:
 - `:Ŵ` or *`:What`* : optimal estimated process noise over ``N_k``, ``\mathbf{Ŵ}``
 - `:ϵ` or *`:epsilon`* : optimal slack variable, ``ϵ``
 - `:X̂` or *`:Xhat`* : optimal estimated states over ``N_k+1``, ``\mathbf{X̂}``
-- `:x̂` or *`:xhat`* : optimal estimated state for the next time step, ``\mathbf{x̂}_k(k+1)``
+- `:x̂` or *`:xhat`* : optimal estimated state, ``\mathbf{x̂}_k(k+p)``
 - `:V̂` or *`:Vhat`* : optimal estimated sensor noise over ``N_k``, ``\mathbf{V̂}``
 - `:P̄` or *`:Pbar`* : estimation error covariance at arrival, ``\mathbf{P̄}``
 - `:x̄` or *`:xbar`* : optimal estimation error at arrival, ``\mathbf{x̄}``

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -445,7 +445,7 @@ function correct_cov!(estim::MovingHorizonEstimator)
         invert_cov!(estim, estim.P̂arr_old)
     catch err
         if err isa PosDefException
-            @warn("Arrival covariance is not positive definite: keeping the old one")
+            @error("Arrival covariance P̄ is not positive definite: keeping the old one")
         else
             rethrow()
         end
@@ -465,7 +465,7 @@ function update_cov!(estim::MovingHorizonEstimator)
         invert_cov!(estim, estim.P̂arr_old)
     catch err
         if err isa PosDefException
-            @warn("Arrival covariance is not positive definite: keeping the old one")
+            @error("Arrival covariance P̄ is not positive definite: keeping the old one")
         else
             rethrow()
         end
@@ -479,7 +479,7 @@ function invert_cov!(estim::MovingHorizonEstimator, P̄)
         estim.invP̄ .= inv_cholesky!(estim.buffer.P̂, P̄)
     catch err
         if err isa PosDefException
-            @warn("Arrival covariance is not invertible: keeping the old one")
+            @error("Arrival covariance P̄ is not invertible: keeping the old one")
         else
             rethrow()
         end

--- a/test/test_state_estim.jl
+++ b/test/test_state_estim.jl
@@ -988,19 +988,19 @@ end
     P̂arr_old_copy = deepcopy(mhe.P̂arr_old)
     invP̄_copy = deepcopy(mhe.invP̄)
     @test_logs(
-        (:error, "Arrival covariance is not positive definite: keeping the old one"), 
+        (:error, "Arrival covariance P̄ is not positive definite: keeping the old one"), 
         preparestate!(mhe, [50, 30], [5])
     )
     @test mhe.P̂arr_old ≈ P̂arr_old_copy
     @test mhe.invP̄ ≈ invP̄_copy
     @test_logs(
-        (:error, "Arrival covariance is not positive definite: keeping the old one"), 
+        (:error, "Arrival covariance P̄ is not positive definite: keeping the old one"), 
         updatestate!(mhe, [10, 50], [50, 30], [5])
     )
     @test mhe.P̂arr_old ≈ P̂arr_old_copy
     @test mhe.invP̄ ≈ invP̄_copy
     @test_logs(
-        (:error, "Arrival covariance is not invertible: keeping the old one"), 
+        (:error, "Arrival covariance P̄ is not invertible: keeping the old one"), 
         ModelPredictiveControl.invert_cov!(mhe, Hermitian(zeros(mhe.nx̂, mhe.nx̂),:L))
     )
 end

--- a/test/test_state_estim.jl
+++ b/test/test_state_estim.jl
@@ -988,19 +988,19 @@ end
     P̂arr_old_copy = deepcopy(mhe.P̂arr_old)
     invP̄_copy = deepcopy(mhe.invP̄)
     @test_logs(
-        (:warn, "Arrival covariance is not positive definite: keeping the old one"), 
+        (:error, "Arrival covariance is not positive definite: keeping the old one"), 
         preparestate!(mhe, [50, 30], [5])
     )
     @test mhe.P̂arr_old ≈ P̂arr_old_copy
     @test mhe.invP̄ ≈ invP̄_copy
     @test_logs(
-        (:warn, "Arrival covariance is not positive definite: keeping the old one"), 
+        (:error, "Arrival covariance is not positive definite: keeping the old one"), 
         updatestate!(mhe, [10, 50], [50, 30], [5])
     )
     @test mhe.P̂arr_old ≈ P̂arr_old_copy
     @test mhe.invP̄ ≈ invP̄_copy
     @test_logs(
-        (:warn, "Arrival covariance is not invertible: keeping the old one"), 
+        (:error, "Arrival covariance is not invertible: keeping the old one"), 
         ModelPredictiveControl.invert_cov!(mhe, Hermitian(zeros(mhe.nx̂, mhe.nx̂),:L))
     )
 end


### PR DESCRIPTION
Following the "convention" throughout the package, a non fatal `@error` log make more sense than `@warn`. 
It's similar to `@error` emitted by an unfeasible MPC problem: something is wrong but there is a fallback. That is, take the solution from the last time step.

Also updated the `CI.yml` with new feature like improved speed with cache v2 and replacing Julia nightly by `pre` testing.