### PR TITLE
added: `linearize!` is allocation-free once again

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
 authors = ["Francis Gagnon"]
-version = "1.3.4"
+version = "1.3.5"
 
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"

--- a/src/general.jl
+++ b/src/general.jl
@@ -6,6 +6,29 @@ const DEFAULT_LWT = 0.0
 const DEFAULT_CWT = 1e5
 const DEFAULT_EWT = 0.0
 
+"Abstract type for all differentiation buffers."
+abstract type DifferentiationBuffer end
+
+"Struct with both function and configuration for ForwardDiff differentiation."
+struct JacobianBuffer{FT<:Function, CT<:ForwardDiff.JacobianConfig} <: DifferentiationBuffer
+    f!::FT
+    config::CT
+end
+
+function Base.show(io::IO, buffer::DifferentiationBuffer) 
+    return print(io, "DifferentiationBuffer with a $(typeof(buffer.config).name.name)")
+end
+
+"Create a JacobianBuffer with function `f!`, output `y` and input `x`."
+JacobianBuffer(f!, y, x) = JacobianBuffer(f!, ForwardDiff.JacobianConfig(f!, y, x))
+
+"Compute in-place and return the Jacobian matrix of `buffer.f!` at `x`."
+function jacobian!(
+    A, buffer::JacobianBuffer, y, x
+)
+    return ForwardDiff.jacobian!(A, buffer.f!, y, x, buffer.config)
+end
+
 "Termination status that means 'no solution available'."
 const ERROR_STATUSES = (
     JuMP.INFEASIBLE, JuMP.DUAL_INFEASIBLE, JuMP.LOCALLY_INFEASIBLE, 

--- a/src/sim_model.jl
+++ b/src/sim_model.jl
@@ -29,13 +29,13 @@ struct SimModelBuffer{NT<:Real}
 end
 
 @doc raw"""
-    SimModelBuffer{NT}(nu::Int, nx::Int, ny::Int, nd::Int)
+    SimModelBuffer{NT}(nu::Int, nx::Int, ny::Int, nd::Int, linearization=nothing)
 
 Create a buffer for `SimModel` objects for inputs, states, outputs, and disturbances.
 
 The buffer is used to store intermediate results during simulation without allocating.
 """
-function SimModelBuffer{NT}(nu::Int, nx::Int, ny::Int, nd::Int) where {NT <: Real}
+function SimModelBuffer{NT}(nu::Int, nx::Int, ny::Int, nd::Int, ) where {NT<:Real}
     u = Vector{NT}(undef, nu)
     x = Vector{NT}(undef, nx)
     y = Vector{NT}(undef, ny)
@@ -371,5 +371,5 @@ to_mat(A::Real, dims...) = fill(A, dims)
 
 include("model/linmodel.jl")
 include("model/solver.jl")
-include("model/nonlinmodel.jl")
 include("model/linearization.jl")
+include("model/nonlinmodel.jl")

--- a/test/1_test_sim_model.jl
+++ b/test/1_test_sim_model.jl
@@ -285,9 +285,8 @@ end
     @test linmodel1.Bd ≈ linmodel2.Bd
     @test linmodel1.C  ≈ linmodel2.C
     @test linmodel1.Dd ≈ linmodel2.Dd 
-
-    display(nonlinmodel1.linbuffer)
-    display(nonlinmodel1.linbuffer.buffer_f_at_u_d)
+    @test repr(nonlinmodel1.linbuffer) == "LinearizationBuffer object"
+    @test repr(nonlinmodel1.linbuffer.buffer_f_at_u_d) == "DifferentiationBuffer with a JacobianConfig"
 
     f1!(ẋ, x, u, d, _) = (ẋ .= x.^5 + u.^4 + d.^3; nothing)
     h1!(y, x, d, _) = (y .= x.^2 + d; nothing)

--- a/test/1_test_sim_model.jl
+++ b/test/1_test_sim_model.jl
@@ -286,6 +286,9 @@ end
     @test linmodel1.C  ≈ linmodel2.C
     @test linmodel1.Dd ≈ linmodel2.Dd 
 
+    display(nonlinmodel1.linbuffer)
+    display(nonlinmodel1.linbuffer.buffer_f_at_u_d)
+
     f1!(ẋ, x, u, d, _) = (ẋ .= x.^5 + u.^4 + d.^3; nothing)
     h1!(y, x, d, _) = (y .= x.^2 + d; nothing)
     nonlinmodel3 = NonLinModel(f1!,h1!,Ts,1,1,1,1,solver=RungeKutta())

--- a/test/4_test_plot_sim.jl
+++ b/test/4_test_plot_sim.jl
@@ -2,7 +2,8 @@
     using .SetupMPCtests, ControlSystemsBase, LinearAlgebra
     model = LinModel(sys, Ts, i_d=[3])
     res = sim!(model, 15)
-    display(res)
+
+    @test repr(res) == "Simulation results of LinModel with 15 time steps."
     @test isa(res.obj, LinModel)
     @test length(res.T_data) == 15
     @test res.U_data[:, 1] ≈ model.uop .+ 1


### PR DESCRIPTION
Re-designed the Jacobian and linearization buffers for an implementation that is a bit simpler, cleaner and also modular (will also work with gradients and hessians, normally)

Also prepare the ground for migration to `DifferentiationInterface.jl`.

There is no type-instability at runtime, tested on my side with `@code_warntype`.

Related to #162 