### PR TITLE
Changed: major NLP refactoring for flexibility and significantly improve performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
 authors = ["Francis Gagnon"]
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -515,7 +515,7 @@ end
 
 """
     get_optim_functions(
-        mpc::NonLinMPC, ::JuMP.GenericModel
+        mpc::NonLinMPC, optim::JuMP.GenericModel
     ) -> Jfunc, ∇Jfunc!, gfuncs, ∇gfuncs!, geqfuncs, ∇geqfuncs!
 
 Return the functions for the nonlinear optimization of `mpc` [`NonLinMPC`](@ref) controller.
@@ -563,7 +563,7 @@ function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT
     function update_simulations!(
         Z̃arg::Union{NTuple{N, T}, AbstractVector{T}}, Z̃cache
     ) where {N, T<:Real}
-        if isdifferent(Z̃cache, Z̃arg) # new Z̃, update:
+        if isdifferent(Z̃cache, Z̃arg)
             for i in eachindex(Z̃cache)
                 # Z̃cache .= Z̃arg is type unstable with Z̃arg::NTuple{N, FowardDiff.Dual}
                 Z̃cache[i] = Z̃arg[i]
@@ -600,7 +600,7 @@ function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT
         ΔŨ = get_tmp(ΔŨ_cache, T)
         Ue, Ŷe = get_tmp(Ue_cache, T), get_tmp(Ŷe_cache, T)
         U0, Ŷ0 = get_tmp(U0_cache, T), get_tmp(Ŷ0_cache, T)
-        return obj_nonlinprog!(Ŷ0, U0, mpc, model, Ue, Ŷe, ΔŨ)
+        return obj_nonlinprog!(Ŷ0, U0, mpc, model, Ue, Ŷe, ΔŨ)::T
     end
     Z̃_∇J      = fill(myNaN, nZ̃) 
     ∇J        = Vector{JNT}(undef, nZ̃)       # gradient of objective J

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -667,7 +667,7 @@ function init_nonlincon!(
     Z̃var = optim[:Z̃var]
     for i in 1:con.neq
         name = Symbol("geq_$i")
-        geqfunc_i = JuMP.add_nonlinear_operator(optim, nZ̃, geqfuncs[i]; name)
+        geqfunc_i = optim[name] = JuMP.add_nonlinear_operator(optim, nZ̃, geqfuncs[i]; name)
         # set with @constrains here instead of set_nonlincon!, since the number of nonlinear 
         # equality constraints is known and constant (±Inf are impossible):
         @constraint(optim, geqfunc_i(Z̃var...) == 0)

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -1343,9 +1343,9 @@ function get_optim_functions(
             end
             Z̃ = Z̃cache
             ϵ = (nϵ ≠ 0) ? Z̃[begin] : zero(T) # ϵ = 0 if Cwt=Inf (meaning: no relaxation)
-            V̂,  X̂0 = get_tmp(V̂_cache, Z̃1),  get_tmp(X̂0_cache, Z̃1)
-            û0, ŷ0 = get_tmp(û0_cache, Z̃1), get_tmp(ŷ0_cache, Z̃1)
-            g      = get_tmp(g_cache, Z̃1)
+            V̂,  X̂0 = get_tmp(V̂_cache, T),  get_tmp(X̂0_cache, T)
+            û0, ŷ0 = get_tmp(û0_cache, T), get_tmp(ŷ0_cache, T)
+            g      = get_tmp(g_cache, T)
             V̂, X̂0  = predict!(V̂, X̂0, û0, ŷ0, estim, model, Z̃)
             g = con_nonlinprog!(g, estim, model, X̂0, V̂, ϵ)
         end
@@ -1353,12 +1353,14 @@ function get_optim_functions(
     end
     # --------------------- objective functions -------------------------------------------
     function Jfunc(Z̃arg::Vararg{T, N}) where {N, T<:Real}
-        update_simulations!(Z̃arg, get_tmp(Z̃_cache, T))
+        Z̃ = get_tmp(Z̃_cache, T)
+        update_simulations!(Z̃arg, Z̃)
         x̄, V̂ = get_tmp(x̄_cache, T), get_tmp(V̂_cache, T)
         return obj_nonlinprog!(x̄, estim, model, V̂, Z̃)::T
     end
     function Jfunc_vec(Z̃arg::AbstractVector{T}) where T<:Real
-        update_simulations!(Z̃arg, get_tmp(Z̃_cache, T))
+        Z̃ = get_tmp(Z̃_cache, T)
+        update_simulations!(Z̃arg, Z̃)
         x̄, V̂ = get_tmp(x̄_cache, T), get_tmp(V̂_cache, T)
         return obj_nonlinprog!(x̄, estim, model, V̂, Z̃)::T
     end

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -1255,7 +1255,7 @@ function init_optimization!(
             JuMP.set_attribute(optim, "nlp_scaling_max_gradient", 10.0/C)
         end
     end
-    Jfunc, gfuncs = get_optim_functions(estim, optim)
+    Jfunc, ∇Jfunc!, gfuncs, ∇gfuncs! = get_optim_functions(estim, optim)
     @operator(optim, J, nZ̃, Jfunc)
     @objective(optim, Min, J(Z̃var...))
     nV̂, nX̂ = estim.He*estim.nym, estim.He*estim.nx̂
@@ -1293,10 +1293,26 @@ end
 
 
 """
-    get_optim_functions(estim::MovingHorizonEstimator, ::JuMP.GenericModel) -> Jfunc, gfuncs
+    get_optim_functions(
+        estim::MovingHorizonEstimator, optim::JuMP.GenericModel
+    ) -> Jfunc, ∇Jfunc!, gfuncs, ∇gfuncs!
 
-Get the objective `Jfunc` function and constraint `gfuncs` function vector for 
-[`MovingHorizonEstimator`](@ref).
+Return the functions for the nonlinear optimization of [`MovingHorizonEstimator`](@ref).
+
+Return the nonlinear objective `Jfunc` function, and `∇Jfunc!`, to compute its gradient. 
+Also return vectors with the nonlinear inequality constraint functions `gfuncs`, and 
+`∇gfuncs!`, for the associated gradients. 
+
+This method is really indicated and I'm not proud of it. That's because of 3 elements:
+
+- These functions are used inside the nonlinear optimization, so they must be type-stable
+  and as efficient as possible.
+- The `JuMP` NLP syntax forces splatting for the decision variable, which implies use
+  of `Vararg{T,N}` (see the [performance tip](https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing))
+  and memoization to avoid redundant computations. This is already complex, but it's even
+  worse knowing that most automatic differentiation tools do not support splatting.
+- The signature of gradient and hessian functions is not the same for univariate (`nZ̃ == 1`)
+  and multivariate (`nZ̃ > 1`) operators in `JuMP`. Both must be defined.
 
 Inspired from: [User-defined operators with vector outputs](https://jump.dev/JuMP.jl/stable/tutorials/nonlinear/tips_and_tricks/#User-defined-operators-with-vector-outputs)
 """
@@ -1306,51 +1322,100 @@ function get_optim_functions(
     model, con = estim.model, estim.con
     nx̂, nym, nŷ, nu, nϵ, He = estim.nx̂, estim.nym, model.ny, model.nu, estim.nϵ, estim.He
     nV̂, nX̂, ng, nZ̃ = He*nym, He*nx̂, length(con.i_g), length(estim.Z̃)
-    Nc = nZ̃ + 3
+    Ncache = nZ̃ + 3
     myNaN = convert(JNT, NaN) # fill Z̃ with NaNs to force update_simulations! at 1st call:
-    Z̃_cache::DiffCache{Vector{JNT}, Vector{JNT}}  = DiffCache(fill(myNaN, nZ̃), Nc)
-    V̂_cache::DiffCache{Vector{JNT}, Vector{JNT}}  = DiffCache(zeros(JNT, nV̂),  Nc)
-    g_cache::DiffCache{Vector{JNT}, Vector{JNT}}  = DiffCache(zeros(JNT, ng),  Nc)
-    X̂0_cache::DiffCache{Vector{JNT}, Vector{JNT}} = DiffCache(zeros(JNT, nX̂),  Nc)
-    x̄_cache::DiffCache{Vector{JNT}, Vector{JNT}}  = DiffCache(zeros(JNT, nx̂),  Nc)
-    û0_cache::DiffCache{Vector{JNT}, Vector{JNT}} = DiffCache(zeros(JNT, nu),  Nc)
-    ŷ0_cache::DiffCache{Vector{JNT}, Vector{JNT}} = DiffCache(zeros(JNT, nŷ),  Nc)
+    # ---------------------- differentiation cache ---------------------------------------
+    Z̃_cache::DiffCache{Vector{JNT}, Vector{JNT}}  = DiffCache(fill(myNaN, nZ̃), Ncache)
+    V̂_cache::DiffCache{Vector{JNT}, Vector{JNT}}  = DiffCache(zeros(JNT, nV̂),  Ncache)
+    g_cache::DiffCache{Vector{JNT}, Vector{JNT}}  = DiffCache(zeros(JNT, ng),  Ncache)
+    X̂0_cache::DiffCache{Vector{JNT}, Vector{JNT}} = DiffCache(zeros(JNT, nX̂),  Ncache)
+    x̄_cache::DiffCache{Vector{JNT}, Vector{JNT}}  = DiffCache(zeros(JNT, nx̂),  Ncache)
+    û0_cache::DiffCache{Vector{JNT}, Vector{JNT}} = DiffCache(zeros(JNT, nu),  Ncache)
+    ŷ0_cache::DiffCache{Vector{JNT}, Vector{JNT}} = DiffCache(zeros(JNT, nŷ),  Ncache)
     # --------------------- update simulation function ------------------------------------
-    function update_simulations!(Z̃, Z̃tup::NTuple{N, T}) where {N, T <:Real}
-        if any(new !== old for (new, old) in zip(Z̃tup, Z̃)) # new Z̃tup, update predictions:
-            Z̃1 = Z̃tup[begin]
-            for i in eachindex(Z̃tup)
-                Z̃[i] = Z̃tup[i] # Z̃ .= Z̃tup seems to produce a type instability
+    function update_simulations!(
+        Z̃arg::Union{NTuple{N, T}, AbstractVector{T}}, Z̃cache
+    ) where {N, T <:Real}
+        if isdifferent(Z̃cache, Z̃arg)
+            for i in eachindex(Z̃cache)
+                # Z̃cache .= Z̃arg is type unstable with Z̃arg::NTuple{N, FowardDiff.Dual}
+                Z̃cache[i] = Z̃arg[i]
             end
+            Z̃ = Z̃cache
+            ϵ = (nϵ ≠ 0) ? Z̃[begin] : zero(T) # ϵ = 0 if Cwt=Inf (meaning: no relaxation)
             V̂,  X̂0 = get_tmp(V̂_cache, Z̃1),  get_tmp(X̂0_cache, Z̃1)
             û0, ŷ0 = get_tmp(û0_cache, Z̃1), get_tmp(ŷ0_cache, Z̃1)
             g      = get_tmp(g_cache, Z̃1)
             V̂, X̂0  = predict!(V̂, X̂0, û0, ŷ0, estim, model, Z̃)
-            ϵ = (nϵ ≠ 0) ? Z̃[begin] : zero(T) # ϵ = 0 if Cwt=Inf (meaning: no relaxation)
             g = con_nonlinprog!(g, estim, model, X̂0, V̂, ϵ)
         end
         return nothing
     end
-    function Jfunc(Z̃tup::Vararg{T, N}) where {N, T<:Real}
-        Z̃1 = Z̃tup[begin]
-        Z̃ = get_tmp(Z̃_cache, Z̃1)
-        update_simulations!(Z̃, Z̃tup)
-        x̄, V̂ = get_tmp(x̄_cache, Z̃1), get_tmp(V̂_cache, Z̃1)
+    # --------------------- objective functions -------------------------------------------
+    function Jfunc(Z̃arg::Vararg{T, N}) where {N, T<:Real}
+        update_simulations!(Z̃arg, get_tmp(Z̃_cache, T))
+        x̄, V̂ = get_tmp(x̄_cache, T), get_tmp(V̂_cache, T)
         return obj_nonlinprog!(x̄, estim, model, V̂, Z̃)::T
     end
-    function gfunc_i(i, Z̃tup::NTuple{N, T})::T where {N, T <:Real}
-        Z̃1 = Z̃tup[begin]
-        Z̃ = get_tmp(Z̃_cache, Z̃1)
-        update_simulations!(Z̃, Z̃tup)
-        g = get_tmp(g_cache, Z̃1)
-        return g[i]
+    function Jfunc_vec(Z̃arg::AbstractVector{T}) where T<:Real
+        update_simulations!(Z̃arg, get_tmp(Z̃_cache, T))
+        x̄, V̂ = get_tmp(x̄_cache, T), get_tmp(V̂_cache, T)
+        return obj_nonlinprog!(x̄, estim, model, V̂, Z̃)::T
     end
-    gfuncs = Vector{Function}(undef, ng)
-    for i in 1:ng
-        # this is another syntax for anonymous function, allowing parameters T and N:
-        gfuncs[i] = function (ΔŨtup::Vararg{T, N}) where {N, T<:Real}
-            return gfunc_i(i, ΔŨtup)
+    Z̃_∇J      = fill(myNaN, nZ̃) 
+    ∇J        = Vector{JNT}(undef, nZ̃)       # gradient of objective J
+    ∇J_buffer = GradientBuffer(Jfunc_vec, Z̃_∇J)
+    ∇Jfunc! = if nZ̃ == 1
+        function (Z̃arg::T) where T<:Real 
+            Z̃_∇J .= Z̃arg
+            gradient!(∇J, ∇J_buffer, Z̃_∇J)
+            return ∇J[begin]    # univariate syntax, see JuMP.@operator doc
+        end
+    else
+        function (∇J::AbstractVector{T}, Z̃arg::Vararg{T, N}) where {N, T<:Real}
+            Z̃_∇J .= Z̃arg
+            gradient!(∇J, ∇J_buffer, Z̃_∇J)
+            return ∇J           # multivariate syntax, see JuMP.@operator doc
         end
     end
-    return Jfunc, gfuncs
+    # --------------------- inequality constraint functions -------------------------------
+    gfuncs = Vector{Function}(undef, ng)
+    for i in eachindex(gfuncs)
+        func_i = function (Z̃arg::Vararg{T, N}) where {N, T<:Real}
+            update_simulations!(Z̃arg, get_tmp(Z̃_cache, T))
+            g = get_tmp(g_cache, T)
+            return g[i]::T
+        end
+        gfuncs[i] = func_i
+    end
+    function gfunc_vec!(g, Z̃vec::AbstractVector{T}) where T<:Real
+        update_simulations!(Z̃vec, get_tmp(Z̃_cache, T))
+        g .= get_tmp(g_cache, T)
+        return g
+    end
+    Z̃_∇g      = fill(myNaN, nZ̃)
+    g_vec     = Vector{JNT}(undef, ng)
+    ∇g        = Matrix{JNT}(undef, ng, nZ̃)   # Jacobian of inequality constraints g
+    ∇g_buffer = JacobianBuffer(gfunc_vec!, g_vec, Z̃_∇g)
+    ∇gfuncs!  = Vector{Function}(undef, ng)
+    for i in eachindex(∇gfuncs!)
+        ∇gfuncs![i] = if nZ̃ == 1
+            function (Z̃arg::T) where T<:Real
+                if isdifferent(Z̃arg, Z̃_∇g)
+                    Z̃_∇g .= Z̃arg
+                    jacobian!(∇g, ∇g_buffer, g_vec, Z̃_∇g)
+                end
+                return ∇g[i, begin]            # univariate syntax, see JuMP.@operator doc
+            end
+        else
+            function (∇g_i, Z̃arg::Vararg{T, N}) where {N, T<:Real}
+                if isdifferent(Z̃arg, Z̃_∇g)
+                    Z̃_∇g .= Z̃arg
+                    jacobian!(∇g, ∇g_buffer, g_vec, Z̃_∇g)
+                end
+                return ∇g_i .= @views ∇g[i, :] # multivariate syntax, see JuMP.@operator doc
+            end
+        end
+    end
+    return Jfunc, ∇Jfunc!, gfuncs, ∇gfuncs!
 end

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -1256,35 +1256,36 @@ function init_optimization!(
         end
     end
     Jfunc, ∇Jfunc!, gfuncs, ∇gfuncs! = get_optim_functions(estim, optim)
-    @operator(optim, J, nZ̃, Jfunc)
+    @operator(optim, J, nZ̃, Jfunc, ∇Jfunc!)
     @objective(optim, Min, J(Z̃var...))
     nV̂, nX̂ = estim.He*estim.nym, estim.He*estim.nx̂
     if length(con.i_g) ≠ 0
+        i_base = 0
         for i in eachindex(con.X̂0min)
             name = Symbol("g_X̂0min_$i")
             optim[name] = JuMP.add_nonlinear_operator(
-                optim, nZ̃, gfuncs[i]; name
+                optim, nZ̃, gfuncs[i_base + i], ∇gfuncs![i_base + i]; name
             )
         end
-        i_end_X̂min = nX̂
+        i_base = nX̂
         for i in eachindex(con.X̂0max)
             name = Symbol("g_X̂0max_$i")
             optim[name] = JuMP.add_nonlinear_operator(
-                optim, nZ̃, gfuncs[i_end_X̂min + i]; name
+                optim, nZ̃, gfuncs[i_base + i], ∇gfuncs![i_base + i]; name
             )
         end
-        i_end_X̂max = 2*nX̂
+        i_base = 2*nX̂
         for i in eachindex(con.V̂min)
             name = Symbol("g_V̂min_$i")
             optim[name] = JuMP.add_nonlinear_operator(
-                optim, nZ̃, gfuncs[i_end_X̂max + i]; name
+                optim, nZ̃, gfuncs[i_base + i], ∇gfuncs![i_base + i]; name
             )
         end
-        i_end_V̂min = 2*nX̂ + nV̂
+        i_base = 2*nX̂ + nV̂
         for i in eachindex(con.V̂max)
             name = Symbol("g_V̂max_$i")
             optim[name] = JuMP.add_nonlinear_operator(
-                optim, nZ̃, gfuncs[i_end_V̂min + i]; name
+                optim, nZ̃, gfuncs[i_base + i], ∇gfuncs![i_base + i]; name
             )
         end
     end

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -1315,6 +1315,7 @@ function get_optim_functions(
     x̄_cache::DiffCache{Vector{JNT}, Vector{JNT}}  = DiffCache(zeros(JNT, nx̂),  Nc)
     û0_cache::DiffCache{Vector{JNT}, Vector{JNT}} = DiffCache(zeros(JNT, nu),  Nc)
     ŷ0_cache::DiffCache{Vector{JNT}, Vector{JNT}} = DiffCache(zeros(JNT, nŷ),  Nc)
+    # --------------------- update simulation function ------------------------------------
     function update_simulations!(Z̃, Z̃tup::NTuple{N, T}) where {N, T <:Real}
         if any(new !== old for (new, old) in zip(Z̃tup, Z̃)) # new Z̃tup, update predictions:
             Z̃1 = Z̃tup[begin]

--- a/src/general.jl
+++ b/src/general.jl
@@ -91,6 +91,9 @@ function limit_solve_time(optim::GenericModel, Ts)
     end
 end
 
+"Verify that x and y elements are different using `!==`."
+isdifferent(x, y) = any(xi !== yi for (xi, yi) in zip(x, y))
+
 "Generate a block diagonal matrix repeating `n` times the matrix `A`."
 repeatdiag(A, n::Int) = kron(I(n), A)
 

--- a/src/general.jl
+++ b/src/general.jl
@@ -15,16 +15,16 @@ end
 
 "Struct with both function and configuration for ForwardDiff gradient."
 struct GradientBuffer{FT<:Function, CT<:ForwardDiff.GradientConfig} <: DifferentiationBuffer
-    f!::FT
+    f::FT
     config::CT
 end
 
-GradientBuffer(f!, x) = GradientBuffer(f!, ForwardDiff.GradientConfig(f!, x))
+GradientBuffer(f, x) = GradientBuffer(f, ForwardDiff.GradientConfig(f, x))
 
 function gradient!(
     g, buffer::GradientBuffer, x
 )
-    return ForwardDiff.gradient!(g, buffer.f!, x, buffer.config)
+    return ForwardDiff.gradient!(g, buffer.f, x, buffer.config)
 end
 
 "Struct with both function and configuration for ForwardDiff Jacobian."

--- a/src/general.jl
+++ b/src/general.jl
@@ -19,11 +19,11 @@ struct GradientBuffer{FT<:Function, CT<:ForwardDiff.GradientConfig} <: Different
     config::CT
 end
 
+"Create a GradientBuffer with function `f` and input `x`."
 GradientBuffer(f, x) = GradientBuffer(f, ForwardDiff.GradientConfig(f, x))
 
-function gradient!(
-    g, buffer::GradientBuffer, x
-)
+"Compute in-place and return the gradient of `buffer.f` at `x`."
+function gradient!(g, buffer::GradientBuffer, x)
     return ForwardDiff.gradient!(g, buffer.f, x, buffer.config)
 end
 
@@ -33,13 +33,11 @@ struct JacobianBuffer{FT<:Function, CT<:ForwardDiff.JacobianConfig} <: Different
     config::CT
 end
 
-"Create a JacobianBuffer with function `f!`, output `y` and input `x`."
+"Create a JacobianBuffer with in-place function `f!`, output `y` and input `x`."
 JacobianBuffer(f!, y, x) = JacobianBuffer(f!, ForwardDiff.JacobianConfig(f!, y, x))
 
 "Compute in-place and return the Jacobian matrix of `buffer.f!` at `x`."
-function jacobian!(
-    A, buffer::JacobianBuffer, y, x
-)
+function jacobian!(A, buffer::JacobianBuffer, y, x)
     return ForwardDiff.jacobian!(A, buffer.f!, y, x, buffer.config)
 end
 

--- a/src/general.jl
+++ b/src/general.jl
@@ -9,14 +9,28 @@ const DEFAULT_EWT = 0.0
 "Abstract type for all differentiation buffers."
 abstract type DifferentiationBuffer end
 
-"Struct with both function and configuration for ForwardDiff differentiation."
-struct JacobianBuffer{FT<:Function, CT<:ForwardDiff.JacobianConfig} <: DifferentiationBuffer
+function Base.show(io::IO, buffer::DifferentiationBuffer) 
+    return print(io, "DifferentiationBuffer with a $(typeof(buffer.config).name.name)")
+end
+
+"Struct with both function and configuration for ForwardDiff gradient."
+struct GradientBuffer{FT<:Function, CT<:ForwardDiff.GradientConfig} <: DifferentiationBuffer
     f!::FT
     config::CT
 end
 
-function Base.show(io::IO, buffer::DifferentiationBuffer) 
-    return print(io, "DifferentiationBuffer with a $(typeof(buffer.config).name.name)")
+GradientBuffer(f!, x) = GradientBuffer(f!, ForwardDiff.GradientConfig(f!, x))
+
+function gradient!(
+    g, buffer::GradientBuffer, x
+)
+    return ForwardDiff.gradient!(g, buffer.f!, x, buffer.config)
+end
+
+"Struct with both function and configuration for ForwardDiff Jacobian."
+struct JacobianBuffer{FT<:Function, CT<:ForwardDiff.JacobianConfig} <: DifferentiationBuffer
+    f!::FT
+    config::CT
 end
 
 "Create a JacobianBuffer with function `f!`, output `y` and input `x`."

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -990,6 +990,11 @@ end
     info = getinfo(mhe5)
     @test info[:x̂] ≈ x̂ atol=1e-9
     @test info[:Ŷ][end-1:end] ≈ [50, 30] atol=1e-9
+    # for coverage of NLP functions, the univariate syntax of JuMP.@operator
+    mhe6 = MovingHorizonEstimator(nonlinmodel, He=1, Cwt=Inf)
+    setconstraint!(mhe6, v̂min=[-51,-52], v̂max=[53,54])
+    x̂ = preparestate!(mhe6, [50, 30], [5])
+    @test x̂ ≈ zeros(6) atol=1e-9
     @test_nowarn ModelPredictiveControl.info2debugstr(info)
 end
 

--- a/test/3_test_predictive_control.jl
+++ b/test/3_test_predictive_control.jl
@@ -602,10 +602,12 @@ end
     LHS = zeros(1)
     nmpc15.con.gc!(LHS,[1,2],[3,4],[4,6],10,0.1) 
     @test LHS ≈ [10*dot([1,2],[3,4])+sum([4,6])+0.1]
-    nmpc16 = NonLinMPC(nonlinmodel, Hp=10, transcription=MultipleShooting())
+    gc! = (LHS,_,_,_,_,_)-> (LHS .= 0.0) # useless, only for coverage
+    nmpc16 = NonLinMPC(nonlinmodel, Hp=10, transcription=MultipleShooting(), nc=10, gc=gc!)
     @test nmpc16.transcription == MultipleShooting()
     @test length(nmpc16.Z̃) == nonlinmodel.nu*nmpc16.Hc + nmpc16.estim.nx̂*nmpc16.Hp + nmpc16.nϵ
     @test nmpc16.con.neq == nmpc16.estim.nx̂*nmpc16.Hp
+    @test nmpc16.con.nc == 10
     nmpc17 = NonLinMPC(linmodel1, Hp=10, transcription=MultipleShooting())
     @test nmpc17.transcription == MultipleShooting()
     @test length(nmpc17.Z̃) == linmodel1.nu*nmpc17.Hc + nmpc17.estim.nx̂*nmpc17.Hp + nmpc17.nϵ


### PR DESCRIPTION
## First improvement

One big step further toward integration of `DifferentiationInterface.jl`

Related to #162 

## Second improvement

The splatting syntax of `JuMP` forces us to compute the Jacobians of the constraints as a combination of multiple gradients (concatenated as a Jacobian).

This means that the `jacobian` function of the AD tool (dense `ForwardDiff.jl`, for now) were called redundantly `ng` and `neq` times for a specific decision vector value `Z̃` (where `ng` and `neq` is the respective number of nonlinear inequality and equality constraints). This is wasteful. A caching mechanism was implemented to store the Jacobians of the constraints and reuse them when needed. 

The performance improvement is about 5-10x faster now on `NonLinMPC` with `NonLinModel`. Note that it only applies when nonlinear constraints are present (i.e.: output or state constraint of nonlinear plant model, custom constraint and multiple shooting of nonlinear plant model)

FYI @baggepinnen and @1-Bart-1, will release it soon today or tomorrow.

edit : just tested this branch on the pendulum model. Now `MultipleShooting` is only 1.6x slower than the `SingleShooting` transcription (it was more than 5x times slower before), so it's plenty fast enough for real time! I'm really proud of this improvement 🍾🎉🍾 🎉. The additional gains will be using sparse differentiation with `DifferentionInterface.jl`. 