### PR TITLE
Debug `x_noise` argument in `sim!` and deprecate `preparestate!(::SimModel, _ , _ )`

### DIFF
--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -525,7 +525,7 @@ Also return vectors with the nonlinear inequality constraint functions `gfuncs`,
 `∇gfuncs!`, for the associated gradients. Lastly, also return vectors with the nonlinear 
 equality constraint functions `geqfuncs` and gradients `∇geqfuncs!`.
 
-This method is really indicated and I'm not proud of it. That's because of 3 elements:
+This method is really intricate and I'm not proud of it. That's because of 3 elements:
 
 - These functions are used inside the nonlinear optimization, so they must be type-stable
   and as efficient as possible.

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -1275,7 +1275,7 @@ Return the nonlinear objective `Jfunc` function, and `∇Jfunc!`, to compute its
 Also return vectors with the nonlinear inequality constraint functions `gfuncs`, and 
 `∇gfuncs!`, for the associated gradients. 
 
-This method is really indicated and I'm not proud of it. That's because of 3 elements:
+This method is really intricate and I'm not proud of it. That's because of 3 elements:
 
 - These functions are used inside the nonlinear optimization, so they must be type-stable
   and as efficient as possible.

--- a/src/plot_sim.jl
+++ b/src/plot_sim.jl
@@ -286,7 +286,8 @@ function sim_closedloop!(
         d = lastd + d_step + d_noise.*randn(plant.nd)
         y = evaloutput(plant, d) + y_step + y_noise.*randn(plant.ny)
         ym = y[estim.i_ym]
-        preparestate!(est_mpc, ym, d)
+        x  = preparestate!(plant)
+        x̂  = preparestate!(est_mpc, ym, d)
         u  = sim_getu!(est_mpc, u_ry, d, ru)
         ud = u + u_step + u_noise.*randn(plant.nu)
         Y_data[:, i]        .= y
@@ -296,10 +297,10 @@ function sim_closedloop!(
         Ud_data[:, i]       .= ud
         Ru_data[:, i]       .= ru
         D_data[:, i]        .= d
-        X_data[:, i]        .= plant.x0 .+ plant.xop
-        X̂_data[:, i]        .= estim.x̂0 .+ estim.x̂op
-        x = updatestate!(plant, ud, d); 
-        x[:] += x_noise.*randn(plant.nx)
+        X_data[:, i]        .= x
+        X̂_data[:, i]        .= x̂
+        updatestate!(plant, ud, d); 
+        plant.x0 .+= x_noise.*randn(plant.nx)
         updatestate!(est_mpc, u, ym, d)
     end
     res = SimResult(

--- a/src/sim_model.jl
+++ b/src/sim_model.jl
@@ -218,10 +218,13 @@ function preparestate!(model::SimModel)
     return x 
 end
 
-@deprecate function preparestate!(model::SimModel, ::Any , ::Any=model.buffer.empty)
-    x  = model.buffer.x
-    x .= model.x0 .+ model.xop
-    return x 
+function preparestate!(model::SimModel, ::Any , ::Any=model.buffer.empty)
+    Base.depwarn(
+        "The method preparestate!(model::SimModel, u, d=[]) is deprecated. Use "*
+        " preparestate!(model::SimModel) instead.",
+        :preparestate!,
+    )
+    return preparestate!(model)
 end
 
 @doc raw"""

--- a/src/sim_model.jl
+++ b/src/sim_model.jl
@@ -208,11 +208,17 @@ function initstate!(model::SimModel, u, d=model.buffer.empty)
 end
 
 @doc raw"""
-    preparestate!(model::SimModel, _ , _ ) -> x
+    preparestate!(model::SimModel) -> x
 
 Do nothing for [`SimModel`](@ref) and return the current model state ``\mathbf{x}(k)``. 
 """
-function preparestate!(model::SimModel, ::Any , ::Any=model.buffer.empty)
+function preparestate!(model::SimModel)
+    x  = model.buffer.x
+    x .= model.x0 .+ model.xop
+    return x 
+end
+
+@deprecate function preparestate!(model::SimModel, ::Any , ::Any=model.buffer.empty)
     x  = model.buffer.x
     x .= model.x0 .+ model.xop
     return x 

--- a/test/1_test_sim_model.jl
+++ b/test/1_test_sim_model.jl
@@ -107,7 +107,8 @@ end
     @test evaloutput(linmodel1, Float64[]) ≈ linmodel1(Float64[]) ≈ [50,30]
     x = initstate!(linmodel1, [10, 60])
     @test evaloutput(linmodel1) ≈ [50 + 19.0, 30 + 7.4]
-    @test preparestate!(linmodel1, [10, 60]) ≈ x
+    @test preparestate!(linmodel1) ≈ x           # new method
+    @test preparestate!(linmodel1, [10, 60]) ≈ x # deprecated method
     @test updatestate!(linmodel1,  [10, 60]) ≈ x
     linmodel2 = LinModel(append(tf(1, [1, 0]), tf(2, [10, 1])), 1.0)
     x = initstate!(linmodel2, [10, 3])

--- a/test/4_test_plot_sim.jl
+++ b/test/4_test_plot_sim.jl
@@ -65,6 +65,9 @@ end
     @test res_man.D_data ≈ res.D_data
     @test res_man.X_data ≈ res.X_data
     @test res_man.X̂_data ≈ res.X̂_data
+
+    res2 = sim!(estim, 15, x_noise=[0.1, 0.2, 0.3, 0.4])
+    @test !(res2.X_data ≈ res.X_data)
 end
 
 @testitem "StateEstimator Plots" setup=[SetupMPCtests] begin


### PR DESCRIPTION
The `x_noise` keyword argument of `sim!` now works. It also deprecates:

```julia
preparestate!(model::SimModel, ym, d=[])
```
and replace it with:

```julia
preparestate!(model::SimModel)
```

The old method with `ym` and `d` arguments still works but it's now deprecated with `Base.depwarn`. The old method was not making sense since the two arguments were ignored. Moreover, it's now consistent with the `updatestate!` generic function, that is, it receives no measurement as argument for `SimModel`.