### PR TITLE
Added: `ExtendedKalmanFilter` now uses `DifferentiationInterface.jl` + now allocation-free

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ package for Julia.
 The package depends on [`ControlSystemsBase.jl`](https://github.com/JuliaControl/ControlSystems.jl)
 for the linear systems, [`JuMP.jl`](https://github.com/jump-dev/JuMP.jl) for the
 optimization and [`DifferentiationInterface.jl`](https://github.com/JuliaDiff/DifferentiationInterface.jl)
-for the differentiation.
+for the derivatives.
 
 ## Installation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ package for Julia.
 The package depends on [`ControlSystemsBase.jl`](https://github.com/JuliaControl/ControlSystems.jl)
 for the linear systems, [`JuMP.jl`](https://github.com/jump-dev/JuMP.jl) for the
 optimization and [`DifferentiationInterface.jl`](https://github.com/JuliaDiff/DifferentiationInterface.jl)
-for the differentiation.
+for the derivatives.
 
 The objective is to provide a simple, clear and modular framework to quickly design model
 predictive controllers (MPCs) in Julia, while preserving the flexibility for advanced

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -43,11 +43,12 @@ operating point ``\mathbf{x̂_{op}}`` (see [`augment_model`](@ref)):
 ```
 where ``\mathbf{x̂}_i(k+j)`` is the state prediction for time ``k+j``, estimated by the
 observer at time ``i=k`` or ``i=k-1`` depending on its `direct` flag. Note that 
-``\mathbf{X̂_0 = X̂}`` if the operating points is zero, which is typically the case in 
-practice for [`NonLinModel`](@ref). This transcription method is generally more efficient
-for large control horizon ``H_c``, unstable or highly nonlinear plant models/constraints. 
+``\mathbf{X̂_0 = X̂}`` if the operating point is zero, which is typically the case in practice
+for [`NonLinModel`](@ref). This transcription method is generally more efficient for large
+control horizon ``H_c``, unstable or highly nonlinear plant models/constraints. 
 
-Sparse optimizers like `OSQP` or `Ipopt` are recommended for this method.
+Sparse optimizers like `OSQP` or `Ipopt` and sparse Jacobian computations are recommended
+for this transcription method.
 """
 struct MultipleShooting <: TranscriptionMethod end
 

--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -36,7 +36,7 @@ where ``\mathbf{x̂_0}(k+1)`` is stored in `x̂next0` argument. The method mutat
 function signature for conciseness.
 """
 function f̂!(x̂next0, û0, estim::StateEstimator, model::SimModel, x̂0, u0, d0)
-    return f!(x̂next0, û0, model, estim.As, estim.Cs_u, x̂0, u0, d0)
+    return f̂!(x̂next0, û0, model, estim.As, estim.Cs_u, x̂0, u0, d0)
 end
 
 """

--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -36,14 +36,7 @@ where ``\mathbf{x̂_0}(k+1)`` is stored in `x̂next0` argument. The method mutat
 function signature for conciseness.
 """
 function f̂!(x̂next0, û0, estim::StateEstimator, model::SimModel, x̂0, u0, d0)
-    # `@views` macro avoid copies with matrix slice operator e.g. [a:b]
-    @views x̂d, x̂s = x̂0[1:model.nx], x̂0[model.nx+1:end]
-    @views x̂d_next, x̂s_next = x̂next0[1:model.nx], x̂next0[model.nx+1:end]
-    mul!(û0, estim.Cs_u, x̂s)
-    û0 .+= u0
-    f!(x̂d_next, model, x̂d, û0, d0, model.p)
-    mul!(x̂s_next, estim.As, x̂s)
-    return nothing
+    return f!(x̂next0, û0, model, estim.As, estim.Cs_u, x̂0, u0, d0)
 end
 
 """
@@ -58,18 +51,31 @@ function f̂!(x̂next0, _ , estim::StateEstimator, ::LinModel, x̂0, u0, d0)
     return nothing
 end
 
+"""
+    f̂!(x̂next0, û0, model::SimModel, As, Cs_u, x̂0, u0, d0)
+
+Same than [`f̂!`](@ref) for [`SimModel`](@ref) but without the `estim` argument.
+"""
+function f̂!(x̂next0, û0, model::SimModel, As, Cs_u, x̂0, u0, d0)
+    # `@views` macro avoid copies with matrix slice operator e.g. [a:b]
+    @views x̂d, x̂s = x̂0[1:model.nx], x̂0[model.nx+1:end]
+    @views x̂d_next, x̂s_next = x̂next0[1:model.nx], x̂next0[model.nx+1:end]
+    mul!(û0, Cs_u, x̂s)
+    û0 .+= u0
+    f!(x̂d_next, model, x̂d, û0, d0, model.p)
+    mul!(x̂s_next, As, x̂s)
+    return nothing
+end
+
 @doc raw"""
     ĥ!(ŷ0, estim::StateEstimator, model::SimModel, x̂0, d0) -> nothing
 
 Mutating output function ``\mathbf{ĥ}`` of the augmented model, see [`f̂!`](@ref).
 """
 function ĥ!(ŷ0, estim::StateEstimator, model::SimModel, x̂0, d0)
-    # `@views` macro avoid copies with matrix slice operator e.g. [a:b]
-    @views x̂d, x̂s = x̂0[1:model.nx], x̂0[model.nx+1:end]
-    h!(ŷ0, model, x̂d, d0, model.p)
-    mul!(ŷ0, estim.Cs_y, x̂s, 1, 1)
-    return nothing
+    return ĥ!(ŷ0, model, estim.Cs_y, x̂0, d0)
 end
+
 """
     ĥ!(ŷ0, estim::StateEstimator, model::LinModel, x̂0, d0) -> nothing
 
@@ -78,6 +84,19 @@ Use the augmented model matrices if `model` is a [`LinModel`](@ref).
 function ĥ!(ŷ0, estim::StateEstimator, ::LinModel, x̂0, d0)
     mul!(ŷ0, estim.Ĉ,  x̂0)
     mul!(ŷ0, estim.D̂d, d0, 1, 1)
+    return nothing
+end
+
+"""
+    ĥ!(ŷ0, model::SimModel, Cs_y, x̂0, d0)
+
+Same than [`ĥ!`](@ref) for [`SimModel`](@ref) but without the `estim` argument.
+"""
+function ĥ!(ŷ0, model::SimModel, Cs_y, x̂0, d0)
+    # `@views` macro avoid copies with matrix slice operator e.g. [a:b]
+    @views x̂d, x̂s = x̂0[1:model.nx], x̂0[model.nx+1:end]
+    h!(ŷ0, model, x̂d, d0, model.p)
+    mul!(ŷ0, Cs_y, x̂s, 1, 1)
     return nothing
 end
 

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -956,10 +956,9 @@ end
 
 Construct an extended Kalman Filter with the [`SimModel`](@ref) `model`.
 
-Both [`LinModel`](@ref) and [`NonLinModel`](@ref) are supported. The process model and the
-keyword arguments are identical to [`UnscentedKalmanFilter`](@ref), except for `α`, `β` and 
-`κ` which do not apply to the extended Kalman Filter. The Jacobians of the augmented model 
-``\mathbf{f̂, ĥ}`` are computed with [`ForwardDiff`](@extref ForwardDiff) automatic
+Both [`LinModel`](@ref) and [`NonLinModel`](@ref) are supported. The process model is
+identical to [`UnscentedKalmanFilter`](@ref). By default, the Jacobians of the augmented
+model ``\mathbf{f̂, ĥ}`` are computed with [`ForwardDiff`](@extref ForwardDiff) automatic
 differentiation. This estimator is allocation-free if `model` simulations do not allocate.
 !!! warning
     See the Extended Help of [`linearize`](@ref) function if you get an error like:    

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -445,7 +445,10 @@ end
 "Correct the covariance estimate at arrival using `covestim` [`StateEstimator`](@ref)."
 function correct_cov!(estim::MovingHorizonEstimator)
     nym, nd = estim.nym, estim.model.nd
-    y0marr, d0arr = @views estim.Y0m[1:nym], estim.D0[1:nd]
+    buffer = estim.covestim.buffer
+    y0marr, d0arr = buffer.ym, buffer.d
+    y0marr .= @views estim.Y0m[1:nym]
+    d0arr  .= @views estim.D0[1:nd]
     estim.covestim.x̂0 .= estim.x̂0arr_old
     estim.covestim.P̂  .= estim.P̂arr_old
     try
@@ -468,7 +471,11 @@ end
 "Update the covariance estimate at arrival using `covestim` [`StateEstimator`](@ref)."
 function update_cov!(estim::MovingHorizonEstimator)
     nu, nd, nym = estim.model.nu, estim.model.nd, estim.nym
-    u0arr, y0marr, d0arr = @views estim.U0[1:nu], estim.Y0m[1:nym], estim.D0[1:nd]
+    buffer = estim.covestim.buffer
+    u0arr, y0marr, d0arr = buffer.u, buffer.ym, buffer.d
+    u0arr  .= @views estim.U0[1:nu]
+    y0marr .= @views estim.Y0m[1:nym]
+    d0arr  .= @views estim.D0[1:nd]
     estim.covestim.x̂0 .= estim.x̂0arr_old
     estim.covestim.P̂  .= estim.P̂arr_old
     try

--- a/src/model/linearization.jl
+++ b/src/model/linearization.jl
@@ -8,7 +8,7 @@ The function has the following signature:
     linfunc!(xnext, y, A, Bu, C, Bd, Dd, backend, x, u, d, cst_x, cst_u, cst_d) -> nothing
 ```
 and it should modifies in-place all the arguments before `backend`. The `backend` argument
-is an `AbstractADType` backend from `DifferentiationInterface`. The `cst_x`, `cst_u` and 
+is an `AbstractADType` object from `DifferentiationInterface`. The `cst_x`, `cst_u` and 
 `cst_d` are `DifferentiationInterface.Constant` objects with the linearization points.
 """
 function get_linearization_func(NT, f!, h!, nu, nx, ny, nd, p, backend)

--- a/src/model/linearization.jl
+++ b/src/model/linearization.jl
@@ -32,7 +32,7 @@ function get_linearization_func(NT, f!, h!, nu, nx, ny, nd, p, backend)
     C_prep  = prepare_jacobian(h_x!, y,     backend, x, cst_d       ; strict)
     Dd_prep = prepare_jacobian(h_d!, y,     backend, d, cst_x       ; strict)
     function linfunc!(xnext, y, A, Bu, C, Bd, Dd, backend, x, u, d, cst_x, cst_u, cst_d)
-        # all the arguments before `x` are mutated in this function
+        # all the arguments before `backend` are mutated in this function
         jacobian!(f_x!, xnext, A,  A_prep,  backend, x, cst_u, cst_d)
         jacobian!(f_u!, xnext, Bu, Bu_prep, backend, u, cst_x, cst_d)
         jacobian!(f_d!, xnext, Bd, Bd_prep, backend, d, cst_x, cst_u)

--- a/test/3_test_predictive_control.jl
+++ b/test/3_test_predictive_control.jl
@@ -698,7 +698,6 @@ end
     nmpc5 = setconstraint!(nmpc5, ymin=[1])
     # execute update_predictions! branch in `gfunc_i` for coverage:
     g_Y0min_end = nmpc5.optim[:g_Y0min_1].func
-    println(nmpc5.Z̃)
     @test_nowarn g_Y0min_end(10.0, 9.0, 8.0, 7.0)
     # execute update_predictions! branch in `geqfunc_i` for coverage:
     geq_end = nmpc5.optim[:geq_2].func


### PR DESCRIPTION
Following #179, also migrates `ExtendedKalmanFilter` to DI.jl. There is a new `jacobian` keyword arguments to swap the backend.

Bonus: the estimator is now allocation-free at runtime (at least with `AutoForwardDiff`)