### PR TITLE
debug: remove `.data` in `KalmanFilter` matrix products

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
 authors = ["Francis Gagnon"]
-version = "1.5.2"
+version = "1.5.3"
 
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"

--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -125,7 +125,7 @@ julia> estim = SteadyKalmanFilter(LinModel(tf(3, [10, 1]), 0.5), nint_ym=[2], di
 
 julia> u = [1]; y = [3 - 0.1]; x̂ = round.(initstate!(estim, u, y), digits=3)
 3-element Vector{Float64}:
-  5.0
+ 10.0
   0.0
  -0.1
 

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -1210,7 +1210,7 @@ function correct_estimate_kf!(estim::Union{KalmanFilter, ExtendedKalmanFilter}, 
     x̂0, P̂ = estim.x̂0, estim.P̂
     # in-place operations to reduce allocations:
     P̂_Ĉmᵀ = K̂
-    mul!(P̂_Ĉmᵀ, P̂.data, Ĉm') # the ".data" weirdly removes a type instability in mul!
+    mul!(P̂_Ĉmᵀ, P̂, Ĉm')
     M̂ = estim.buffer.R̂
     mul!(M̂, Ĉm, P̂_Ĉmᵀ)
     M̂ .+= R̂
@@ -1252,7 +1252,7 @@ function predict_estimate_kf!(estim::Union{KalmanFilter, ExtendedKalmanFilter}, 
     # in-place operations to reduce allocations:
     f̂!(x̂0next, û0, k0, estim, estim.model, x̂0corr, u0, d0)
     P̂corr_Âᵀ = estim.buffer.P̂
-    mul!(P̂corr_Âᵀ, P̂corr.data, Â') # the ".data" weirdly removes a type instability in mul!
+    mul!(P̂corr_Âᵀ, P̂corr, Â')
     Â_P̂corr_Âᵀ = estim.buffer.Q̂
     mul!(Â_P̂corr_Âᵀ, Â, P̂corr_Âᵀ)
     P̂next  = estim.buffer.P̂

--- a/test/0_test_module.jl
+++ b/test/0_test_module.jl
@@ -3,8 +3,9 @@
     Ts = 400.0
     sys = [ tf(1.90,[1800.0,1])   tf(1.90,[1800.0,1])   tf(1.90,[1800.0,1]);
             tf(-0.74,[800.0,1])   tf(0.74,[800.0,1])    tf(-0.74,[800.0,1])   ] 
-    sys_ss = minreal(ss(sys))
-    Gss = c2d(sys_ss[:,1:2], Ts, :zoh)
-    Gss2 = c2d(sys_ss[:,1:2], 0.5Ts, :zoh)
+    sys_ss = ss(sys)
+    sys_ss_u = sminreal(sys_ss[:,1:2])
+    Gss  = minreal(c2d(sys_ss_u, Ts, :zoh))
+    Gss2 = minreal(c2d(sys_ss_u, 0.5Ts, :zoh))
     export Ts, sys, sys_ss, Gss, Gss2
 end

--- a/test/1_test_sim_model.jl
+++ b/test/1_test_sim_model.jl
@@ -37,9 +37,9 @@
     @test linmodel5.nu == 2
     @test linmodel5.nd == 1
     @test linmodel5.ny == 2
-    sysu_ss = sminreal(c2d(minreal(ss(sys))[:,1:2], Ts, :zoh))
-    sysd_ss = sminreal(c2d(minreal(ss(sys))[:,3],   Ts, :tustin))
-    sys_ss = [sysu_ss sysd_ss]
+    sysu_ss = c2d(sminreal(ss(sys)[:,1:2]), Ts, :zoh)
+    sysd_ss = c2d(sminreal(ss(sys)[:,3]),   Ts, :tustin)
+    sys_ss = minreal([sysu_ss sysd_ss])
     @test linmodel5.A   ≈ sys_ss.A
     @test linmodel5.Bu  ≈ sys_ss.B[:,1:2]
     @test linmodel5.Bd  ≈ sys_ss.B[:,3]
@@ -51,14 +51,19 @@
 
     linmodel6 = LinModel([delay(Ts) delay(Ts)]*sys,Ts,i_d=[3])
     @test linmodel6.nx == 3
-    @test sum(eigvals(linmodel6.A) .≈ 0) == 1
+    @test sum(isapprox.(eigvals(linmodel6.A), 0, atol=1e-15)) == 1
 
-    linmodel7 = LinModel(
-        ss(diagm( .1: .1: .3), I(3), diagm( .4: .1: .6), 0, 1.0), 
-        i_u=[1, 2],
-        i_d=[3])
-    @test linmodel7.A ≈ diagm( .1: .1: .3)
-    @test linmodel7.C ≈ diagm( .4: .1: .6)
+    A = diagm( .1: .1: .3)
+    Bu = [I(2); zeros(1,2)]
+    C = diagm( .4: .1: .6)
+    Bd = [zeros(2,1); I(1)]
+    Dd = 0;
+    linmodel7 = LinModel(A, Bu, C, Bd, Dd, 1.0)
+    @test linmodel7.A ≈ A
+    @test linmodel7.Bu ≈ Bu
+    @test linmodel7.Bd ≈ Bd
+    @test linmodel7.C ≈ C
+    @test linmodel7.Dd ≈ zeros(3,1)
 
     linmodel8 = LinModel(Gss.A, Gss.B, Gss.C, zeros(Float32, 2, 0), zeros(Float32, 2, 0), Ts)
     @test isa(linmodel8, LinModel{Float64})

--- a/test/3_test_predictive_control.jl
+++ b/test/3_test_predictive_control.jl
@@ -705,13 +705,13 @@ end
     @test_nowarn geq_end(5.0, 4.0, 3.0, 2.0)
     nmpc6  = NonLinMPC(linmodel3, Hp=10)
     preparestate!(nmpc6, [0])
-    @test moveinput!(nmpc6, [0]) ≈ [0.0]
+    @test moveinput!(nmpc6, [0]) ≈ [0.0] atol=5e-2
     nonlinmodel2 = NonLinModel{Float32}(f, h, 3000.0, 1, 2, 1, 1, solver=nothing, p=linmodel2)
     nmpc7  = NonLinMPC(nonlinmodel2, Hp=10)
     y = similar(nonlinmodel2.yop)
     nonlinmodel2.solver_h!(y, Float32[0,0], Float32[0], nonlinmodel2.p)
     preparestate!(nmpc7, [0], [0])
-    @test moveinput!(nmpc7, [0], [0]) ≈ [0.0]
+    @test moveinput!(nmpc7, [0], [0]) ≈ [0.0] atol=5e-2
     nmpc8 = NonLinMPC(nonlinmodel, Nwt=[0], Hp=100, Hc=1, transcription=MultipleShooting())
     preparestate!(nmpc8, [0], [0])
     u = moveinput!(nmpc8, [10], [0])


### PR DESCRIPTION
Some matrix products were computed on normal dense matrix using `M.data` instead of `M`, in which `M isa Hermitian`. It was because of a bug in `LinearAlgebra` that produces a dynamic dispatch (https://github.com/JuliaLang/julia/issues/53951). This bug is solved now so it's no longer needed. 

It's also not the best idea for the numerical stability since covariance matrices are `Hermitian`s, and the intermediate matrices in the computation should all be Hermitians also for the consistency.

@1-bart-1 This branch solve the `cholesky!` issue in your exemple on my computer. Give it a try.

I did not try the Joseph form equation here since the `.data` was just bad for the numerical stability, and simply removing that solve the problem. After I merge these changes, If you have any other similar issue with a new piece of code, send it to me. I will try the Joseph form on it to see if it helps. 

related to #98 