### PR TITLE
debug: force update of gradient/jacobian in `MovingHorzionEstimator` when window not filled

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
 authors = ["Francis Gagnon"]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"

--- a/docs/src/internals/state_estim.md
+++ b/docs/src/internals/state_estim.md
@@ -39,6 +39,7 @@ ModelPredictiveControl.linconstraint!(::MovingHorizonEstimator, ::LinModel)
 
 ```@docs
 ModelPredictiveControl.optim_objective!(::MovingHorizonEstimator)
+ModelPredictiveControl.set_warmstart_mhe!
 ```
 
 ## Remove Operating Points

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -583,9 +583,9 @@ function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT
     )
     ∇J_prep = prepare_gradient(Jfunc!, grad, Z̃_∇J, ∇J_context...; strict)
     ∇J = Vector{JNT}(undef, nZ̃)
-    function update_objective!(J, ∇J, Z̃, Z̃arg)
-        if isdifferent(Z̃arg, Z̃)
-            Z̃ .= Z̃arg
+    function update_objective!(J, ∇J, Z̃_∇J, Z̃arg)
+        if isdifferent(Z̃arg, Z̃_∇J)
+            Z̃_∇J .= Z̃arg
             J[], _ = value_and_gradient!(Jfunc!, ∇J, ∇J_prep, grad, Z̃_∇J, ∇J_context...)
         end
     end    
@@ -620,10 +620,10 @@ function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT
     ∇g_prep  = prepare_jacobian(gfunc!, g, jac, Z̃_∇g, ∇g_context...; strict)
     mpc.con.i_g[1:end-nc] .= false
     ∇g = init_diffmat(JNT, jac, ∇g_prep, nZ̃, ng)
-    function update_con!(g, ∇g, Z̃, Z̃arg)
-        if isdifferent(Z̃arg, Z̃)
-            Z̃ .= Z̃arg
-            value_and_jacobian!(gfunc!, g, ∇g, ∇g_prep, jac, Z̃, ∇g_context...)
+    function update_con!(g, ∇g, Z̃_∇g, Z̃arg)
+        if isdifferent(Z̃arg, Z̃_∇g)
+            Z̃_∇g .= Z̃arg
+            value_and_jacobian!(gfunc!, g, ∇g, ∇g_prep, jac, Z̃_∇g, ∇g_context...)
         end
     end
     gfuncs = Vector{Function}(undef, ng)
@@ -662,10 +662,10 @@ function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT
     )
     ∇geq_prep = prepare_jacobian(geqfunc!, geq, jac, Z̃_∇geq, ∇geq_context...; strict)
     ∇geq = init_diffmat(JNT, jac, ∇geq_prep, nZ̃, neq)
-    function update_con_eq!(geq, ∇geq, Z̃, Z̃arg)
-        if isdifferent(Z̃arg, Z̃)
-            Z̃ .= Z̃arg
-            value_and_jacobian!(geqfunc!, geq, ∇geq, ∇geq_prep, jac, Z̃, ∇geq_context...)
+    function update_con_eq!(geq, ∇geq, Z̃_∇geq, Z̃arg)
+        if isdifferent(Z̃arg, Z̃_∇geq)
+            Z̃_∇geq .= Z̃arg
+            value_and_jacobian!(geqfunc!, geq, ∇geq, ∇geq_prep, jac, Z̃_∇geq, ∇geq_context...)
         end
     end
     geqfuncs = Vector{Function}(undef, neq)

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -954,7 +954,7 @@ linconstrainteq!(::PredictiveController, ::SimModel, ::MultipleShooting) = nothi
 @doc raw"""
     set_warmstart!(mpc::PredictiveController, transcription::SingleShooting, Z̃var) -> Z̃s
 
-Set and return the warm start value of `Z̃var` for [`SingleShooting`](@ref) transcription.
+Set and return the warm-start value of `Z̃var` for [`SingleShooting`](@ref) transcription.
 
 If supported by `mpc.optim`, it warm-starts the solver at:
 ```math
@@ -985,7 +985,7 @@ end
 @doc raw"""
     set_warmstart!(mpc::PredictiveController, transcription::MultipleShooting, Z̃var) -> Z̃s
 
-Set and return the warm start value of `Z̃var` for [`MultipleShooting`](@ref) transcription.
+Set and return the warm-start value of `Z̃var` for [`MultipleShooting`](@ref) transcription.
 
 It warm-starts the solver at:
 ```math

--- a/src/estimator/internal_model.jl
+++ b/src/estimator/internal_model.jl
@@ -168,15 +168,15 @@ function matrices_internalmodel(model::SimModel{NT}) where NT<:Real
 end
 
 @doc raw"""
-    f̂!(x̂0next, _ , x̂0i, estim::InternalModel, model::NonLinModel, x̂0, u0, d0)
+    f̂!(x̂0next, _ , k0, estim::InternalModel, model::NonLinModel, x̂0, u0, d0)
 
 State function ``\mathbf{f̂}`` of [`InternalModel`](@ref) for [`NonLinModel`](@ref).
 
-It calls `model.solver_f!(x̂0next, x̂0i, x̂0, u0 ,d0, model.p)` directly since this estimator
+It calls `model.solver_f!(x̂0next, k0, x̂0, u0 ,d0, model.p)` directly since this estimator
 does not augment the states.
 """
-function f̂!(x̂0next, _ , x̂0i, ::InternalModel, model::NonLinModel, x̂0, u0, d0)
-    return model.solver_f!(x̂0next, x̂0i, x̂0, u0, d0, model.p)
+function f̂!(x̂0next, _ , k0, ::InternalModel, model::NonLinModel, x̂0, u0, d0)
+    return model.solver_f!(x̂0next, k0, x̂0, u0, d0, model.p)
 end
 
 @doc raw"""

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -1356,15 +1356,14 @@ function get_optim_functions(
     ∇J_prep = prepare_gradient(Jfunc!, grad, Z̃_∇J, ∇J_context...; strict)
     estim.Nk[] = 0
     ∇J = Vector{JNT}(undef, nZ̃)
-    function update_objective!(J, ∇J, Z̃, Z̃arg)
-        if isdifferent(Z̃arg, Z̃)
-            Z̃ .= Z̃arg
+    function update_objective!(J, ∇J, Z̃_∇J, Z̃arg)
+        if isdifferent(Z̃arg, Z̃_∇J)
+            Z̃_∇J .= Z̃arg
             J[], _ = value_and_gradient!(Jfunc!, ∇J, ∇J_prep, grad, Z̃_∇J, ∇J_context...)
         end
     end
     function Jfunc(Z̃arg::Vararg{T, N}) where {N, T<:Real}
         update_objective!(J, ∇J, Z̃_∇J, Z̃arg)
-        @show J
         return J[]::T
     end
     ∇Jfunc! = function (∇Jarg::AbstractVector{T}, Z̃arg::Vararg{T, N}) where {N, T<:Real}
@@ -1388,10 +1387,10 @@ function get_optim_functions(
     estim.con.i_g .= false
     estim.Nk[] = 0
     ∇g = init_diffmat(JNT, jac, ∇g_prep, nZ̃, ng)
-    function update_con!(g, ∇g, Z̃, Z̃arg)
-        if isdifferent(Z̃arg, Z̃)
-            Z̃ .= Z̃arg
-            value_and_jacobian!(gfunc!, g, ∇g, ∇g_prep, jac, Z̃, ∇g_context...)
+    function update_con!(g, ∇g, Z̃_∇g, Z̃arg)
+        if isdifferent(Z̃arg, Z̃_∇g)
+            Z̃_∇g .= Z̃arg
+            value_and_jacobian!(gfunc!, g, ∇g, ∇g_prep, jac, Z̃_∇g, ∇g_context...)
         end
     end
     gfuncs = Vector{Function}(undef, ng)

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -1364,6 +1364,7 @@ function get_optim_functions(
     end
     function Jfunc(Z̃arg::Vararg{T, N}) where {N, T<:Real}
         update_objective!(J, ∇J, Z̃_∇J, Z̃arg)
+        @show J
         return J[]::T
     end
     ∇Jfunc! = function (∇Jarg::AbstractVector{T}, Z̃arg::Vararg{T, N}) where {N, T<:Real}

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -459,7 +459,7 @@ function set_warmstart_mhe!(V̂, X̂0, estim::MovingHorizonEstimator{NT}, Z̃var
     V̂, X̂0 = predict!(V̂, X̂0, û0, k0, ŷ0, estim, model, Z̃s)
     Js = obj_nonlinprog!(x̄, estim, model, V̂, Z̃s)
     if !isfinite(Js)
-        Z̃s[nx̃+nx̂+1:end] = 0
+        Z̃s[nx̃+1:end] = 0
     end
     # --- unused variable in Z̃ (applied only when Nk ≠ He) ---
     # We force the update of the NLP gradient and jacobian by warm-starting the unused 

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -398,6 +398,7 @@ function optim_objective!(estim::MovingHorizonEstimator{NT}) where NT<:Real
     isfinite(J_0) || (Z̃s = [ϵ_0; estim.x̂0arr_old; zeros(NT, nŵ*estim.He)])
     JuMP.set_start_value.(Z̃var, Z̃s)
     # ------- solve optimization problem --------------
+    println("optimizing!")
     try
         JuMP.optimize!(optim)
     catch err
@@ -434,9 +435,11 @@ function optim_objective!(estim::MovingHorizonEstimator{NT}) where NT<:Real
     end
     # --------- update estimate -----------------------
     estim.Ŵ[1:nŵ*Nk] .= @views estim.Z̃[nx̃+1:nx̃+nŵ*Nk] # update Ŵ with optimum for warm-start
+    println("solved, needs to call predict! one more time.")
     V̂, X̂0 = predict!(V̂, X̂0, û0, k0, ŷ0, estim, model, estim.Z̃)
     x̂0next    = @views X̂0[end-nx̂+1:end] 
     estim.x̂0 .= x̂0next
+    @show estim.Ŵ[1:nŵ*Nk]
     return estim.Z̃
 end
 
@@ -596,6 +599,10 @@ function predict!(V̂, X̂0, û0, k0, ŷ0, estim::MovingHorizonEstimator, mode
             x̂0next .+= ŵ .+ estim.f̂op .- estim.x̂op
             x̂0 = x̂0next
         end
+    end
+    if eltype(X̂0) == Float64
+        @show X̂0
+        @show V̂
     end
     return V̂, X̂0
 end


### PR DESCRIPTION
In some corner cases (e.g. when `nint_u≠0`, not sure why I did not see this bug when `nint_ym≠0`), the caching of the gradient and jacobian `MovingHorizonEstimator` NLP problem was not working well at the beginning (when the measurement window is not filled, or $N_k \ne H_e$). I added a hack with a clever warm-starting to force the update of the gradient/jacobian when the window is not filled.

Note that it's impossible to shrink the decision variable vector `Z̃`  in `JuMP.jl`, AFAIK. That would be the cleanest solution  when the window is not filled (at the beginning). My workaround is to "ignore" some decision variable in `Z̃` in the cost and constraint functions at the beginning (for the NLP case, not QP). That is why this clever hack work.

I will add a test for this bug.