### PR TITLE
debug: support `Hermitian` weights in `PredictiveController`

### DIFF
--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -88,9 +88,9 @@ struct ControllerWeights{
 end
 
 "Outer constructor to convert weight matrix number type to `NT` if necessary."
-function ControllerWeights{NT}(
-        model, Hp, Hc, M_Hp::MW, N_Hc::NW, L_Hp::LW, Cwt=Inf, Ewt=0
-    ) where {NT<:Real, MW<:AbstractMatrix, NW<:AbstractMatrix, LW<:AbstractMatrix}
+function ControllerWeights(
+        model::SimModel{NT}, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt=Inf, Ewt=0
+    ) where {NT<:Real}
     return ControllerWeights{NT}(model, Hp, Hc, NT.(M_Hp), NT.(N_Hc), NT.(L_Hp), Cwt, Ewt)
 end
 

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -53,14 +53,13 @@ struct ControllerWeights{
     iszero_E::Bool
     isinf_C ::Bool
     function ControllerWeights{NT}(
-        model, Hp, Hc, M_Hp::MW, N_Hc::NW, L_Hp::LW, Cwt=Inf, Ewt=0
+        M_Hp::MW, N_Hc::NW, L_Hp::LW, Cwt, Ewt
     ) where {
         NT<:Real, 
         MW<:AbstractMatrix{NT}, 
         NW<:AbstractMatrix{NT}, 
         LW<:AbstractMatrix{NT}
     }
-        validate_weights(model, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt, Ewt)
         nΔU = size(N_Hc, 1)
         C = Cwt
         isinf_C = isinf(C)
@@ -87,11 +86,12 @@ struct ControllerWeights{
     end
 end
 
-"Outer constructor to convert weight matrix number type to `NT` if necessary."
+"Outer constructor to validate and convert weight matrices if necessary."
 function ControllerWeights(
         model::SimModel{NT}, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt=Inf, Ewt=0
     ) where {NT<:Real}
-    return ControllerWeights{NT}(model, Hp, Hc, NT.(M_Hp), NT.(N_Hc), NT.(L_Hp), Cwt, Ewt)
+    validate_weights(model, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt, Ewt)
+    return ControllerWeights{NT}(NT.(M_Hp), NT.(N_Hc), NT.(L_Hp), Cwt, Ewt)
 end
 
 "Include all the data for the constraints of [`PredictiveController`](@ref)"

--- a/src/controller/explicitmpc.jl
+++ b/src/controller/explicitmpc.jl
@@ -169,7 +169,7 @@ function ExplicitMPC(
     end
     nb = move_blocking(Hp, Hc)
     Hc = get_Hc(nb)
-    weights = ControllerWeights{NT}(estim.model, Hp, Hc, M_Hp, N_Hc, L_Hp)
+    weights = ControllerWeights(estim.model, Hp, Hc, M_Hp, N_Hc, L_Hp)
     return ExplicitMPC{NT}(estim, Hp, Hc, nb, weights)
 end
 

--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -270,7 +270,7 @@ function LinMPC(
     end
     nb = move_blocking(Hp, Hc)
     Hc = get_Hc(nb)
-    weights = ControllerWeights{NT}(estim.model, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt)
+    weights = ControllerWeights(estim.model, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt)
     return LinMPC{NT}(estim, Hp, Hc, nb, weights, transcription, optim)
 end
 

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -372,7 +372,7 @@ function NonLinMPC(
     Hc = get_Hc(nb)
     validate_JE(NT, JE)
     gc! = get_mutating_gc(NT, gc)
-    weights = ControllerWeights{NT}(estim.model, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt, Ewt)
+    weights = ControllerWeights(estim.model, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt, Ewt)
     return NonLinMPC{NT}(
         estim, Hp, Hc, nb, weights, JE, gc!, nc, p, transcription, optim, gradient, jacobian
     )

--- a/src/general.jl
+++ b/src/general.jl
@@ -65,6 +65,9 @@ isdifferent(x, y) = any(xi !== yi for (xi, yi) in zip(x, y))
 
 "Generate a block diagonal matrix repeating `n` times the matrix `A`."
 repeatdiag(A, n::Int) = kron(I(n), A)
+function repeatdiag(A::Hermitian{NT, Diagonal{NT, Vector{NT}}}, n::Int) where {NT<:Real}
+    return Hermitian(repeatdiag(A.data, n), :L) # to return hermitian of a `Diagonal`
+end
 
 "In-place version of `repeat` but for vectors only."
 function repeat!(Y::Vector, a::Vector, n::Int)

--- a/test/3_test_predictive_control.jl
+++ b/test/3_test_predictive_control.jl
@@ -29,14 +29,14 @@
     mpc9 = LinMPC(model, nint_u=[1, 1], nint_ym=[0, 0])
     @test mpc9.estim.nint_u  == [1, 1]
     @test mpc9.estim.nint_ym == [0, 0]
-    mpc10 = LinMPC(model, M_Hp=diagm(collect(1.01:0.01:1.2)))
-    @test mpc10.weights.M_Hp ≈ diagm(collect(1.01:0.01:1.2))
+    mpc10 = LinMPC(model, M_Hp=Hermitian(diagm(1.01:0.01:1.2), :L))
+    @test mpc10.weights.M_Hp ≈ diagm(1.01:0.01:1.2)
     @test mpc10.weights.M_Hp isa Hermitian{Float64, Matrix{Float64}}
-    mpc11 = LinMPC(model, N_Hc=diagm([0.1,0.11,0.12,0.13]), Cwt=Inf)
+    mpc11 = LinMPC(model, N_Hc=Hermitian(diagm([0.1,0.11,0.12,0.13]), :L), Cwt=Inf)
     @test mpc11.weights.Ñ_Hc ≈ diagm([0.1,0.11,0.12,0.13])
     @test mpc11.weights.Ñ_Hc isa Hermitian{Float64, Matrix{Float64}}
-    mcp12 = LinMPC(model, L_Hp=diagm(collect(0.001:0.001:0.02)))
-    @test mcp12.weights.L_Hp ≈ diagm(collect(0.001:0.001:0.02))
+    mcp12 = LinMPC(model, L_Hp=Hermitian(diagm(0.001:0.001:0.02), :L))
+    @test mcp12.weights.L_Hp ≈ diagm(0.001:0.001:0.02)
     @test mcp12.weights.L_Hp isa Hermitian{Float64, Matrix{Float64}}
     model2 = LinModel{Float32}(0.5*ones(1,1), ones(1,1), ones(1,1), zeros(1,0), zeros(1,0), 1.0)
     mpc13  = LinMPC(model2)
@@ -463,14 +463,14 @@ end
     mpc9 = ExplicitMPC(model, nint_u=[1, 1], nint_ym=[0, 0])
     @test mpc9.estim.nint_u  == [1, 1]
     @test mpc9.estim.nint_ym == [0, 0]
-    mpc10 = ExplicitMPC(model, M_Hp=diagm(collect(1.01:0.01:1.2)))
-    @test mpc10.weights.M_Hp ≈ diagm(collect(1.01:0.01:1.2))
+    mpc10 = ExplicitMPC(model, M_Hp=Hermitian(diagm(1.01:0.01:1.2), :L))
+    @test mpc10.weights.M_Hp ≈ diagm(1.01:0.01:1.2)
     @test mpc10.weights.M_Hp isa Hermitian{Float64, Matrix{Float64}}
-    mpc11 = ExplicitMPC(model, N_Hc=diagm([0.1,0.11,0.12,0.13]))
+    mpc11 = ExplicitMPC(model, N_Hc=Hermitian(diagm([0.1,0.11,0.12,0.13]), :L))
     @test mpc11.weights.Ñ_Hc ≈ diagm([0.1,0.11,0.12,0.13])
     @test mpc11.weights.Ñ_Hc isa Hermitian{Float64, Matrix{Float64}}
-    mcp12 = ExplicitMPC(model, L_Hp=diagm(collect(0.001:0.001:0.02)))
-    @test mcp12.weights.L_Hp ≈ diagm(collect(0.001:0.001:0.02))
+    mcp12 = ExplicitMPC(model, L_Hp=Hermitian(diagm(0.001:0.001:0.02), :L))
+    @test mcp12.weights.L_Hp ≈ diagm(0.001:0.001:0.02)
     @test mcp12.weights.L_Hp isa Hermitian{Float64, Matrix{Float64}}
     model2 = LinModel{Float32}(0.5*ones(1,1), ones(1,1), ones(1,1), zeros(1,0), zeros(1,0), 1.0)
     mpc13  = ExplicitMPC(model2)
@@ -671,14 +671,14 @@ end
     nmpc11 = NonLinMPC(nonlinmodel, Hp=15, nint_u=[1, 1], nint_ym=[0, 0])
     @test nmpc11.estim.nint_u  == [1, 1]
     @test nmpc11.estim.nint_ym == [0, 0]
-    nmpc12 = NonLinMPC(nonlinmodel, Hp=10, M_Hp=diagm(collect(1.01:0.01:1.2)))
-    @test nmpc12.weights.M_Hp ≈ diagm(collect(1.01:0.01:1.2))
+    nmpc12 = NonLinMPC(nonlinmodel, Hp=10, M_Hp=Hermitian(diagm(1.01:0.01:1.2), :L))
+    @test nmpc12.weights.M_Hp ≈ diagm(1.01:0.01:1.2)
     @test nmpc12.weights.M_Hp isa Hermitian{Float64, Matrix{Float64}}
-    nmpc13 = NonLinMPC(nonlinmodel, Hp=10, N_Hc=diagm([0.1,0.11,0.12,0.13]), Cwt=Inf)
+    nmpc13 = NonLinMPC(nonlinmodel, Hp=10, N_Hc=Hermitian(diagm([0.1,0.11,0.12,0.13]), :L), Cwt=Inf)
     @test nmpc13.weights.Ñ_Hc ≈ diagm([0.1,0.11,0.12,0.13])
     @test nmpc13.weights.Ñ_Hc isa Hermitian{Float64, Matrix{Float64}}
-    nmcp14 = NonLinMPC(nonlinmodel, Hp=10, L_Hp=diagm(collect(0.001:0.001:0.02)))
-    @test nmcp14.weights.L_Hp ≈ diagm(collect(0.001:0.001:0.02))
+    nmcp14 = NonLinMPC(nonlinmodel, Hp=10, L_Hp=Hermitian(diagm(0.001:0.001:0.02), :L))
+    @test nmcp14.weights.L_Hp ≈ diagm(0.001:0.001:0.02)
     @test nmcp14.weights.L_Hp isa Hermitian{Float64, Matrix{Float64}}
     nmpc15 = NonLinMPC(nonlinmodel, Hp=10, gc=(Ue,Ŷe,D̂e,p,ϵ)-> [p*dot(Ue,Ŷe)+sum(D̂e)+ϵ], nc=1, p=10)
     LHS = zeros(1)


### PR DESCRIPTION
Constructing with e.g.:
```julia
mpc = LinMPC(model, M_Hp=Hermitian(diagm(ones(10)))
```
was crashing.  I added generic dispatch to convert correctly and handle all matrix types correctly.