### PR TITLE
debug: do not warn `cond(H̃)` in `NonLinMPC` if `Ewt≠0`

### DIFF
--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -586,7 +586,7 @@ at [`relaxŶ`](@ref), [`relaxΔU`](@ref) and [`relaxU`](@ref) documentation, re
 vector ``\mathbf{q̃}`` and scalar ``r`` need recalculation each control period ``k``, see
 [`initpred!`](@ref). ``r`` does not impact the minima position. It is thus useless at
 optimization but required to evaluate the minimal ``J`` value. A `@warn` will be displayed
-if the condition number `cond(H̃) ≥ warn_cond` and `transcription` is a `SingleShooting` 
+if the condition number `cond(H̃) > warn_cond` and `transcription` is a `SingleShooting` 
 (`warn_cond=Inf` for no warning).
 """
 function init_quadprog(

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -103,7 +103,8 @@ struct NonLinMPC{
             Eŝ, Fŝ, Gŝ, Jŝ, Kŝ, Vŝ, Bŝ,
             gc!, nc
         )
-        H̃ = init_quadprog(model, transcription, weights, Ẽ, P̃Δu, P̃u)
+        warn_cond = iszero(weights.E) ? 1e6 : Inf # condition number warning only if Ewt==0
+        H̃ = init_quadprog(model, transcription, weights, Ẽ, P̃Δu, P̃u; warn_cond)
         # dummy vals (updated just before optimization):
         q̃, r = zeros(NT, size(H̃, 1)), zeros(NT, 1)
         Ks, Ps = init_stochpred(estim, Hp)


### PR DESCRIPTION
It does make sense to test the condition number of the Hessian if there is no custom objective function, but otherwise it does not make sense.