### PR TITLE
doc: continue line numbers in "Manual" section

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,7 +28,7 @@ makedocs(
     sitename    = "ModelPredictiveControl.jl",
     #format = Documenter.LaTeX(platform = "none"),
     doctest     = true,
-    plugins     = [links,CodeBlocks()],
+    plugins     = [links, CodeBlocks()],
     format      = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true",
         edit_link = "main"

--- a/docs/src/manual/installation.md
+++ b/docs/src/manual/installation.md
@@ -1,5 +1,9 @@
 # Manual: Installation
 
+```@codeblocks
+line_counter = :continue
+```
+
 To install the `ModelPredictiveControl` package, run this command in the Julia REPL:
 
 ```julia

--- a/docs/src/manual/installation.md
+++ b/docs/src/manual/installation.md
@@ -1,10 +1,10 @@
 # Manual: Installation
 
+To install the `ModelPredictiveControl` package, run this command in the Julia REPL:
+
 ```@codeblocks
 line_counter = :continue
 ```
-
-To install the `ModelPredictiveControl` package, run this command in the Julia REPL:
 
 ```julia
 using Pkg; Pkg.activate(); Pkg.add("ModelPredictiveControl")

--- a/docs/src/manual/linmpc.md
+++ b/docs/src/manual/linmpc.md
@@ -4,10 +4,6 @@
 Pages = ["linmpc.md"]
 ```
 
-```@codeblocks
-line_counter = :continue
-```
-
 ## Linear Model
 
 The example considers a continuously stirred-tank reactor (CSTR) with a cold and hot water
@@ -50,6 +46,10 @@ the following linear model accurately describes the plant dynamics:
 
 We first need to construct a [`LinModel`](@ref) objet with [`setop!`](@ref) to handle the
 operating points:
+
+```@codeblocks
+line_counter = :continue
+```
 
 ```@example 1
 using ModelPredictiveControl, ControlSystemsBase

--- a/docs/src/manual/linmpc.md
+++ b/docs/src/manual/linmpc.md
@@ -4,6 +4,10 @@
 Pages = ["linmpc.md"]
 ```
 
+```@codeblocks
+line_counter = :continue
+```
+
 ## Linear Model
 
 The example considers a continuously stirred-tank reactor (CSTR) with a cold and hot water

--- a/docs/src/manual/mtk.md
+++ b/docs/src/manual/mtk.md
@@ -4,6 +4,10 @@
 Pages = ["mtk.md"]
 ```
 
+```@codeblocks
+line_counter = :continue
+```
+
 ```@setup 1
 using Logging; errlogger = ConsoleLogger(stderr, Error);
 old_logger = global_logger(); global_logger(errlogger);

--- a/docs/src/manual/mtk.md
+++ b/docs/src/manual/mtk.md
@@ -4,10 +4,6 @@
 Pages = ["mtk.md"]
 ```
 
-```@codeblocks
-line_counter = :continue
-```
-
 ```@setup 1
 using Logging; errlogger = ConsoleLogger(stderr, Error);
 old_logger = global_logger(); global_logger(errlogger);
@@ -27,6 +23,10 @@ the last section.
     will work for all corner cases.
 
 We first construct and instantiate the pendulum model:
+
+```@codeblocks
+line_counter = :continue
+```
 
 ```@example 1
 using ModelPredictiveControl, ModelingToolkit

--- a/docs/src/manual/nonlinmpc.md
+++ b/docs/src/manual/nonlinmpc.md
@@ -4,10 +4,6 @@
 Pages = ["nonlinmpc.md"]
 ```
 
-```@codeblocks
-line_counter = :continue
-```
-
 ## Nonlinear Model
 
 In this example, the goal is to control the angular position ``θ`` of a pendulum
@@ -43,6 +39,10 @@ the end of the pendulum in kg, all bundled in the parameter vector ``\mathbf{p} 
 [\begin{smallmatrix} g & L & K & m \end{smallmatrix}]'``. The [`NonLinModel`](@ref)
 constructor assumes by default that the state function `f` is continuous in time, that is,
 an ordinary differential equation system (like here):
+
+```@codeblocks
+line_counter = :continue
+```
 
 ```@example man_nonlin
 using ModelPredictiveControl

--- a/docs/src/manual/nonlinmpc.md
+++ b/docs/src/manual/nonlinmpc.md
@@ -4,6 +4,10 @@
 Pages = ["nonlinmpc.md"]
 ```
 
+```@codeblocks
+line_counter = :continue
+```
+
 ## Nonlinear Model
 
 In this example, the goal is to control the angular position ``θ`` of a pendulum


### PR DESCRIPTION
This is more natural like this, the code a the bottom of the page depends on the code at the top.