### PR TITLE
ci: modifying the permissions for stable doc deployment

### DIFF
--- a/.github/workflows/juliaci.yml
+++ b/.github/workflows/juliaci.yml
@@ -1,9 +1,18 @@
 name: Julia CI
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 on:
-  push: {branches: [main,master]}
-  pull_request: {types: [opened,synchronize,reopened,ready_for_review,converted_to_draft]}
-  issue_comment: {types: [created]}
+  push:
+    branches: [main,master]
+    tags: ['v*']
+  pull_request:
+    types: [opened,synchronize,reopened,ready_for_review,converted_to_draft]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       feature:
@@ -20,6 +29,5 @@ jobs:
       include-windows-x86: false
       include-linux-x86: false
       include-macos-x64: false
-    permissions: write-all
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Add explicit permissions (contents/pages/id-token) and enable pushes on tag refs so Documenter.jl can deploy docs from tag-created releases. Remove deprecated write-all usage.\n\nThis ensures the DocDeploy job can push to gh-pages and that docs are deployed on releases (tags).\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>