### PR TITLE
test: add linux x86 32-bit testing

### DIFF
--- a/.github/workflows/juliaci.yml
+++ b/.github/workflows/juliaci.yml
@@ -16,9 +16,7 @@ jobs:
     uses: julia-testitems/testitem-workflow/.github/workflows/juliaci.yml@v2
     with:
       memory-threshold: 0.9
-      include-rc-versions: true
       include-windows-x86: false
-      include-linux-x86: false
       include-macos-x64: false
     permissions: write-all
     secrets:


### PR DESCRIPTION
The issue in `DAQP.jl` on 32-bit systems should be solved now. Let's see the result.