### PR TITLE
added: slightly reduce precompilation time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
-version = "2.12.2"
+version = "2.12.3"
 authors = ["Francis Gagnon"]
 
 [deps]

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -26,7 +26,7 @@ function JE( _ , Ŷe, _ , R̂y , _ )
     Ȳ = R̂y - Ŷ
     return dot(Ȳ, Ȳ)
 end
-R̂y = repeat([55; 30], 10)
+R̂y = repeat([55; 30], 3)
 
 # all calls in this block will be precompiled, regardless of whether
 # they belong to your package or not (on Julia 1.8 and higher)
@@ -34,13 +34,6 @@ R̂y = repeat([55; 30], 10)
 
     model = setop!(LinModel(sys, Ts), uop=[10, 10], yop=[50, 30])
     y = model()
-
-    mpc_im = setconstraint!(LinMPC(InternalModel(model)), ymin=[45, -Inf])
-    initstate!(mpc_im, model.uop, y)
-    preparestate!(mpc_im, [55, 30])
-    mpc_im.estim()
-    u = mpc_im([55, 30])
-    sim!(mpc_im, 2)
 
     mpc_skf = setconstraint!(LinMPC(SteadyKalmanFilter(model)), ymin=[45, -Inf])
     initstate!(mpc_skf, model.uop, model())
@@ -57,22 +50,17 @@ R̂y = repeat([55; 30], 10)
     u = mpc_kf([55, 30])
     sim!(mpc_kf, 2, [55, 30])
 
-    mhe = MovingHorizonEstimator(model, He=2, direct=true)
+    mpc_im = setconstraint!(LinMPC(InternalModel(model)), ymin=[45, -Inf])
+    initstate!(mpc_im, model.uop, y)
+    preparestate!(mpc_im, [55, 30])
+    mpc_im.estim()
+    u = mpc_im([55, 30])
+
+    mhe = MovingHorizonEstimator(model, He=2)
     mhe = setconstraint!(mhe, x̂min=[-50,-50,-50,-50], x̂max=[50,50,50,50])
     initstate!(mhe, model.uop, model())
     preparestate!(mhe, [55, 30])
     mhe()
-
-    mpc_man = setconstraint!(LinMPC(ManualEstimator(model)), ymin=[45, -Inf])
-    initstate!(mpc_man, model.uop, model())
-    setstate!(mpc_man, ones(4))
-    mpc_man([55, 30])
-
-    nmpc_skf = setconstraint!(NonLinMPC(SteadyKalmanFilter(model), Cwt=Inf), ymin=[45, -Inf])
-    initstate!(nmpc_skf, model.uop, model())
-    preparestate!(nmpc_skf, [55, 30])
-    nmpc_skf.estim()
-    nmpc_skf([55, 30])
 
     res = sim!(model, 2)
     res_man = SimResult(model, res.U_data, res.Y_data; X_data=res.X_data)
@@ -88,33 +76,21 @@ R̂y = repeat([55; 30], 10)
     y = nlmodel()
 
     transcription = MultipleShooting(f_threads=true)
-    nmpc_ukf = setconstraint!(NonLinMPC(
-        UnscentedKalmanFilter(nlmodel); Hp=10, transcription, Cwt=1e3), ymin=[45, -Inf]
+    nmpc_ukf = setconstraint!(
+        NonLinMPC(nlmodel; Hp=3, Mwt=[0, 0], Ewt=1, JE=JE, p=R̂y, transcription),
+        ymin=[45, -Inf]
     )
-    initstate!(nmpc_ukf, nlmodel.uop, y)
-    preparestate!(nmpc_ukf, [55, 30])
-    nmpc_ukf([55, 30])
     sim!(nmpc_ukf, 2, [55, 30])
 
-    nmpc_ekf = setconstraint!(NonLinMPC(ExtendedKalmanFilter(model), Cwt=Inf), ymin=[45, -Inf])
-    initstate!(nmpc_ekf, model.uop, model())
-    preparestate!(nmpc_ekf, [55, 30])
-    nmpc_ekf([55, 30])
-
-    transcription = OrthogonalCollocation()
+    transcription = OrthogonalCollocation(0, 2)
     nmpc_mhe = setconstraint!(NonLinMPC(
-        MovingHorizonEstimator(nlmodel, He=2); transcription, Hp=10, Cwt=Inf), ymin=[45, -Inf]
+        MovingHorizonEstimator(nlmodel; He=2, transcription); transcription, Hp=3, Cwt=Inf), 
+        ymin=[45, -Inf]
     )
     setconstraint!(nmpc_mhe.estim, x̂min=[-50,-50,-50,-50], x̂max=[50,50,50,50])
     initstate!(nmpc_mhe, nlmodel.uop, y)
     preparestate!(nmpc_mhe, [55, 30])
     nmpc_mhe([55, 30])
-
-    empc = setconstraint!(
-        NonLinMPC(nlmodel, Mwt=[0, 0], Hp=10, Cwt=Inf, Ewt=1, JE=JE, p=R̂y), ymin=[45, -Inf]
-    )
-    preparestate!(empc, [55, 30])
-    empc()
 
     linearizemodel = linearize(nlmodel)
     setmodel!(mpc_kf, linearizemodel)


### PR DESCRIPTION
Precompilation was taking ~ 500 sec, down to ~ 375 sec now.  

I tried to remove calls that are redundant, reduced the size of the optimization problems in the workload, and removed construction of types that I consider less important (for exemple: `ExtendedKalmanFilter`, the default is `UnscentedKalmanFilter`, which is generally considered a better alternative to `ExtendedKalmanFilter`). It should not affect TTFX too much in most cases.